### PR TITLE
Add linter policy

### DIFF
--- a/policies/linter/README.md
+++ b/policies/linter/README.md
@@ -1,10 +1,10 @@
-# `linter` Policies
+# Linter Policies
 
-Ensures linting runs and passes with acceptable warning counts.
+Policies for validating that linting runs and passes with acceptable warning counts.
 
 ## Overview
 
-This policy enforces linting standards across programming languages. It verifies that linting was executed and that lint warnings are within acceptable limits.
+This policy plugin enforces code quality standards by validating that linting tools are configured and run as part of your CI pipeline. It checks that linting was executed and that the number of warnings stays within acceptable limits, helping maintain consistent code style and catch common bugs early.
 
 ## Policies
 
@@ -24,14 +24,7 @@ This policy reads from the following Component JSON paths:
 | `.lang.{language}.lint` | object | Language-specific linter collector |
 | `.lang.{language}.lint.warnings` | array | Language-specific linter collector |
 
-**Note:** Ensure the corresponding collector(s) are configured before enabling this policy.
-
-## Inputs
-
-| Input | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `language` | **Yes** | `""` | Programming language to check (e.g., "go", "java", "python") |
-| `max_warnings` | No | `0` | Maximum lint warnings allowed (0 = no warnings allowed) |
+**Note:** Ensure the corresponding collector is configured before enabling this policy.
 
 ## Installation
 
@@ -59,36 +52,23 @@ policies:
       max_warnings: "10"  # Allow up to 10 warnings
 ```
 
-### Just Check Linting Ran
-
-```yaml
-policies:
-  - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
-    on: [go]
-    include: [ran]  # Only check that linting occurred
-    enforcement: block-pr
-    with:
-      language: "go"
-```
-
 ## Examples
 
-### Passing Example (zero warnings)
+### Passing Example
 
 ```json
 {
   "lang": {
     "go": {
       "lint": {
-        "warnings": [],
-        "linters": ["golangci-lint"]
+        "warnings": []
       }
     }
   }
 }
 ```
 
-### Failing Example (too many warnings)
+### Failing Example
 
 ```json
 {
@@ -96,8 +76,7 @@ policies:
     "go": {
       "lint": {
         "warnings": [
-          {"file": "main.go", "line": 10, "message": "unused variable", "linter": "unused"},
-          {"file": "util.go", "line": 25, "message": "error not checked", "linter": "errcheck"}
+          {"file": "main.go", "line": 10, "message": "unused variable"}
         ]
       }
     }
@@ -105,25 +84,7 @@ policies:
 }
 ```
 
-**Failure message:** `"Found 2 lint warning(s), maximum allowed is 0"`
-
-### Failing Example (linting not run)
-
-```json
-{
-  "lang": {
-    "go": {}
-  }
-}
-```
-
-**Failure message:** `"No linting data found for go. Ensure a linter is configured to run (e.g., golangci-lint for Go)."`
-
-## Related Collectors
-
-This policy works with any collector that populates the normalized lint data structure:
-
-- [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) - Runs golangci-lint for Go projects
+**Failure message:** `"Found 1 lint warning(s), maximum allowed is 0"`
 
 ## Remediation
 

--- a/policies/linter/README.md
+++ b/policies/linter/README.md
@@ -1,0 +1,134 @@
+# `linter` Policies
+
+Ensures linting runs and passes with acceptable warning counts.
+
+## Overview
+
+This policy enforces linting standards across programming languages. It verifies that linting was executed and that lint warnings are within acceptable limits.
+
+## Policies
+
+This plugin provides the following policies (use `include` to select a subset):
+
+| Policy | Description | Failure Meaning |
+|--------|-------------|-----------------|
+| `lint-ran` | Ensures linting was executed | Linting was not run or no linter is configured |
+| `lint-warnings` | Ensures lint warnings are at or below threshold | Too many lint warnings in the codebase |
+
+## Required Data
+
+This policy reads from the following Component JSON paths:
+
+| Path | Type | Provided By |
+|------|------|-------------|
+| `.lang.{language}.lint` | object | Language-specific linter collector |
+| `.lang.{language}.lint.warnings` | array | Language-specific linter collector |
+
+**Note:** Ensure the corresponding collector(s) are configured before enabling this policy.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `language` | **Yes** | `""` | Programming language to check (e.g., "go", "java", "python") |
+| `max_warnings` | No | `0` | Maximum lint warnings allowed (0 = no warnings allowed) |
+
+## Installation
+
+Add to your `lunar-config.yml`:
+
+```yaml
+policies:
+  - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
+    on: [go]  # Or use domain: ["domain:your-domain"]
+    enforcement: report-pr
+    with:
+      language: "go"
+      max_warnings: "0"
+```
+
+### Lenient Mode (allow some warnings)
+
+```yaml
+policies:
+  - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
+    on: [go]
+    enforcement: block-pr
+    with:
+      language: "go"
+      max_warnings: "10"  # Allow up to 10 warnings
+```
+
+### Just Check Linting Ran
+
+```yaml
+policies:
+  - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
+    on: [go]
+    include: [lint-ran]  # Only check that linting occurred
+    enforcement: block-pr
+    with:
+      language: "go"
+```
+
+## Examples
+
+### Passing Example (zero warnings)
+
+```json
+{
+  "lang": {
+    "go": {
+      "lint": {
+        "warnings": [],
+        "linters": ["golangci-lint"]
+      }
+    }
+  }
+}
+```
+
+### Failing Example (too many warnings)
+
+```json
+{
+  "lang": {
+    "go": {
+      "lint": {
+        "warnings": [
+          {"file": "main.go", "line": 10, "message": "unused variable", "linter": "unused"},
+          {"file": "util.go", "line": 25, "message": "error not checked", "linter": "errcheck"}
+        ]
+      }
+    }
+  }
+}
+```
+
+**Failure message:** `"Found 2 lint warning(s), maximum allowed is 0"`
+
+### Failing Example (linting not run)
+
+```json
+{
+  "lang": {
+    "go": {}
+  }
+}
+```
+
+**Failure message:** `"No linting data found for go. Ensure a linter is configured to run (e.g., golangci-lint for Go)."`
+
+## Related Collectors
+
+This policy works with any collector that populates the normalized lint data structure:
+
+- [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) - Runs golangci-lint for Go projects
+
+## Remediation
+
+When this policy fails, you can resolve it by:
+
+1. **Configure a linter**: Ensure a linter collector is running (e.g., the `golang` collector with `golangci-lint`)
+2. **Fix lint warnings**: Review the lint output and fix the reported issues
+3. **Adjust threshold**: If adopting linting incrementally, set `max_warnings` to a higher value and reduce over time

--- a/policies/linter/README.md
+++ b/policies/linter/README.md
@@ -12,8 +12,8 @@ This plugin provides the following policies (use `include` to select a subset):
 
 | Policy | Description | Failure Meaning |
 |--------|-------------|-----------------|
-| `lint-ran` | Ensures linting was executed | Linting was not run or no linter is configured |
-| `lint-warnings` | Ensures lint warnings are at or below threshold | Too many lint warnings in the codebase |
+| `ran` | Ensures linting was executed | Linting was not run or no linter is configured |
+| `max-warnings` | Ensures lint warnings are at or below threshold | Too many lint warnings in the codebase |
 
 ## Required Data
 
@@ -65,7 +65,7 @@ policies:
 policies:
   - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
     on: [go]
-    include: [lint-ran]  # Only check that linting occurred
+    include: [ran]  # Only check that linting occurred
     enforcement: block-pr
     with:
       language: "go"

--- a/policies/linter/assets/linter.svg
+++ b/policies/linter/assets/linter.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <!-- Document/code file background -->
+  <rect x="12" y="4" width="40" height="52" rx="3" fill="#1D63ED"/>
+  
+  <!-- Code lines -->
+  <rect x="18" y="12" width="20" height="3" rx="1.5" fill="white"/>
+  <rect x="18" y="19" width="28" height="3" rx="1.5" fill="white" opacity="0.7"/>
+  <rect x="18" y="26" width="16" height="3" rx="1.5" fill="white" opacity="0.7"/>
+  <rect x="18" y="33" width="24" height="3" rx="1.5" fill="white" opacity="0.7"/>
+  
+  <!-- Checkmark circle (lint passed indicator) -->
+  <circle cx="48" cy="48" r="12" fill="#10B981"/>
+  <path d="M43 48 L46 51 L53 44" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/policies/linter/lint-ran.py
+++ b/policies/linter/lint-ran.py
@@ -1,0 +1,20 @@
+from lunar_policy import Check, variable_or_default
+
+with Check("lint-ran", "Ensures linting was executed") as c:
+    language = variable_or_default("language", "")
+    
+    # Validate required input
+    if not language:
+        raise ValueError(
+            "Policy misconfiguration: 'language' must be specified. "
+            "Set this to the programming language to check (e.g., 'go', 'java', 'python')."
+        )
+    
+    # Check that lint data exists
+    lint_path = f".lang.{language}.lint"
+    
+    c.assert_exists(
+        lint_path,
+        f"No linting data found for {language}. "
+        f"Ensure a linter is configured to run (e.g., golangci-lint for Go)."
+    )

--- a/policies/linter/lint-ran.py
+++ b/policies/linter/lint-ran.py
@@ -1,6 +1,6 @@
 from lunar_policy import Check, variable_or_default
 
-with Check("lint-ran", "Ensures linting was executed") as c:
+with Check("ran", "Ensures linting was executed") as c:
     language = variable_or_default("language", "")
     
     # Validate required input
@@ -9,6 +9,11 @@ with Check("lint-ran", "Ensures linting was executed") as c:
             "Policy misconfiguration: 'language' must be specified. "
             "Set this to the programming language to check (e.g., 'go', 'java', 'python')."
         )
+    
+    # Skip if this language is not present in the component
+    lang_node = c.get_node(f".lang.{language}")
+    if not lang_node.exists():
+        c.skip(f"No {language} code detected in this component")
     
     # Check that lint data exists
     lint_path = f".lang.{language}.lint"

--- a/policies/linter/lint-warnings.py
+++ b/policies/linter/lint-warnings.py
@@ -1,0 +1,37 @@
+from lunar_policy import Check, variable_or_default
+
+with Check("lint-warnings", "Ensures lint warnings are at or below the maximum allowed") as c:
+    language = variable_or_default("language", "")
+    max_warnings_str = variable_or_default("max_warnings", "0")
+    
+    # Validate required input
+    if not language:
+        raise ValueError(
+            "Policy misconfiguration: 'language' must be specified. "
+            "Set this to the programming language to check (e.g., 'go', 'java', 'python')."
+        )
+    
+    # Parse max_warnings
+    try:
+        max_warnings = int(max_warnings_str)
+    except ValueError:
+        raise ValueError(
+            f"Policy misconfiguration: 'max_warnings' must be an integer, got '{max_warnings_str}'"
+        )
+    
+    # Check for lint warnings
+    lint_path = f".lang.{language}.lint"
+    warnings_path = f"{lint_path}.warnings"
+    
+    # Use assert_exists to handle pending vs missing correctly
+    c.assert_exists(lint_path, f"No linting data found for {language}")
+    
+    warnings = c.get_node(warnings_path)
+    if warnings.exists():
+        warning_count = len(list(warnings))
+        c.assert_less_or_equal(
+            warning_count,
+            max_warnings,
+            f"Found {warning_count} lint warning(s), maximum allowed is {max_warnings}"
+        )
+    # If lint data exists but no warnings array - treat as 0 warnings (pass)

--- a/policies/linter/lint-warnings.py
+++ b/policies/linter/lint-warnings.py
@@ -1,6 +1,6 @@
 from lunar_policy import Check, variable_or_default
 
-with Check("lint-warnings", "Ensures lint warnings are at or below the maximum allowed") as c:
+with Check("max-warnings", "Ensures lint warnings are at or below the maximum allowed") as c:
     language = variable_or_default("language", "")
     max_warnings_str = variable_or_default("max_warnings", "0")
     
@@ -18,6 +18,11 @@ with Check("lint-warnings", "Ensures lint warnings are at or below the maximum a
         raise ValueError(
             f"Policy misconfiguration: 'max_warnings' must be an integer, got '{max_warnings_str}'"
         )
+    
+    # Skip if this language is not present in the component
+    lang_node = c.get_node(f".lang.{language}")
+    if not lang_node.exists():
+        c.skip(f"No {language} code detected in this component")
     
     # Check for lint warnings
     lint_path = f".lang.{language}.lint"

--- a/policies/linter/lunar-policy.yml
+++ b/policies/linter/lunar-policy.yml
@@ -1,0 +1,24 @@
+version: 0
+
+name: linter
+description: Checks that linting ran and passes with acceptable warning count
+author: support@earthly.dev
+
+default_image: earthly/lunar-scripts:1.0.0
+
+policies:
+  - name: lint-ran
+    description: Ensures linting was executed
+    mainPython: ./lint-ran.py
+
+  - name: lint-warnings
+    description: Ensures lint warnings are at or below the maximum allowed
+    mainPython: ./lint-warnings.py
+
+inputs:
+  language:
+    description: Programming language to check (e.g., "go", "java", "python")
+    default: ""
+  max_warnings:
+    description: Maximum number of lint warnings allowed (0 = no warnings allowed)
+    default: "0"

--- a/policies/linter/lunar-policy.yml
+++ b/policies/linter/lunar-policy.yml
@@ -7,11 +7,11 @@ author: support@earthly.dev
 default_image: earthly/lunar-scripts:1.0.0
 
 policies:
-  - name: lint-ran
+  - name: ran
     description: Ensures linting was executed
     mainPython: ./lint-ran.py
 
-  - name: lint-warnings
+  - name: max-warnings
     description: Ensures lint warnings are at or below the maximum allowed
     mainPython: ./lint-warnings.py
 

--- a/policies/linter/lunar-policy.yml
+++ b/policies/linter/lunar-policy.yml
@@ -2,18 +2,39 @@ version: 0
 
 name: linter
 description: Checks that linting ran and passes with acceptable warning count
-author: support@earthly.dev
+author: earthly
 
 default_image: earthly/lunar-scripts:1.0.0
 
+landing_page:
+  display_name: "Linter Policies"
+  long_description: |
+    Enforce code quality standards by validating that linting tools run and pass.
+    Ensures consistent code style, catches common bugs, and maintains codebase health
+    by tracking lint warnings against configurable thresholds.
+  category: "code-quality"
+  icon: "assets/linter.svg"
+  status: "stable"
+  requires:
+    - slug: "golang"
+      type: "collector"
+      reason: "Provides lint data for Go projects via golangci-lint"
+  related: []
+
 policies:
   - name: ran
-    description: Ensures linting was executed
+    description: |
+      Ensures linting was executed for the specified language.
+      Fails if no lint data is found, indicating the linter was not configured or did not run.
     mainPython: ./lint-ran.py
+    keywords: ["linting", "code quality", "static analysis", "ci"]
 
   - name: max-warnings
-    description: Ensures lint warnings are at or below the maximum allowed
+    description: |
+      Ensures lint warnings are at or below the maximum allowed threshold.
+      Validates that the codebase maintains acceptable lint warning counts.
     mainPython: ./lint-warnings.py
+    keywords: ["linting", "warnings", "code quality", "threshold"]
 
 inputs:
   language:

--- a/policies/linter/lunar-policy.yml
+++ b/policies/linter/lunar-policy.yml
@@ -12,7 +12,7 @@ landing_page:
     Enforce code quality standards by validating that linting tools run and pass.
     Ensures consistent code style, catches common bugs, and maintains codebase health
     by tracking lint warnings against configurable thresholds.
-  category: "code-quality"
+  category: "testing-and-quality"
   icon: "assets/linter.svg"
   status: "stable"
   requires:

--- a/policies/linter/requirements.txt
+++ b/policies/linter/requirements.txt
@@ -1,0 +1,1 @@
+lunar-policy==0.2.2


### PR DESCRIPTION
Adds a generic linter policy that checks linting results across any programming language.

## What this does
Provides two checks:
- **lint-ran**: Ensures linting was executed (data exists)
- **lint-warnings**: Ensures lint warnings are at or below a configurable threshold

## Configuration
- `language`: Programming language to check (e.g., 'go', 'java', 'python')
- `max_warnings`: Maximum number of lint warnings allowed (default: 0)

## Data Structure
Reads from the normalized `.lang.{language}.lint` structure populated by language-specific collectors (e.g., golang collector).

## Testing
Tested with the pantalasa test environment using Go projects with golangci-lint data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linter policies to verify lint execution for code
  * Added policy to enforce maximum allowed warning limits
  * Supports language-specific lint configuration and validation

* **Documentation**
  * Added policy documentation with configuration examples and remediation guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->