### PR TITLE
Fix VCS policies to handle missing data gracefully

### DIFF
--- a/policies/vcs/allowed-merge-strategies.py
+++ b/policies/vcs/allowed-merge-strategies.py
@@ -3,6 +3,9 @@ from lunar_policy import Check, variable_or_default
 
 def main():
     with Check("allowed-merge-strategies", "Merge strategies should match allowed list") as c:
+        c.assert_exists(".vcs.merge_strategies", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         allowed_merge_strategies = variable_or_default("allowed_merge_strategies", "")
         allowed_list = [s.strip().lower() for s in allowed_merge_strategies.split(",") if s.strip()]
 

--- a/policies/vcs/branch-protection-enabled.py
+++ b/policies/vcs/branch-protection-enabled.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("branch-protection-enabled", "Branch protection should be enabled") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         branch = c.get_value_or_default(".vcs.branch_protection.branch", "default branch")
 

--- a/policies/vcs/disallow-branch-deletion.py
+++ b/policies/vcs/disallow-branch-deletion.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("disallow-branch-deletion", "Branch deletions should be disallowed") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/disallow-force-push.py
+++ b/policies/vcs/disallow-force-push.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("disallow-force-push", "Force pushes should be disallowed") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/dismiss-stale-reviews.py
+++ b/policies/vcs/dismiss-stale-reviews.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("dismiss-stale-reviews", "Stale reviews should be dismissed") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/minimum-approvals.py
+++ b/policies/vcs/minimum-approvals.py
@@ -3,6 +3,9 @@ from lunar_policy import Check, variable_or_default
 
 def main():
     with Check("minimum-approvals", "Pull requests should require minimum number of approvals") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/require-branches-up-to-date.py
+++ b/policies/vcs/require-branches-up-to-date.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-branches-up-to-date", "Branches should be required to be up to date") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/require-codeowner-review.py
+++ b/policies/vcs/require-codeowner-review.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-codeowner-review", "Code owner review should be required") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/require-default-branch.py
+++ b/policies/vcs/require-default-branch.py
@@ -3,6 +3,9 @@ from lunar_policy import Check, variable_or_default
 
 def main():
     with Check("require-default-branch", "Default branch should match required name") as c:
+        c.assert_exists(".vcs.default_branch", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         required_default_branch = variable_or_default("required_default_branch", "main")
         default_branch = c.get_value(".vcs.default_branch")
 

--- a/policies/vcs/require-linear-history.py
+++ b/policies/vcs/require-linear-history.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-linear-history", "Linear history should be required") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/require-private.py
+++ b/policies/vcs/require-private.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-private", "Repository must be private") as c:
+        c.assert_exists(".vcs.visibility", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         visibility = c.get_value(".vcs.visibility")
         c.assert_equal(visibility, "private", f"Repository visibility is '{visibility}', but policy requires 'private'")
 

--- a/policies/vcs/require-pull-request.py
+++ b/policies/vcs/require-pull-request.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-pull-request", "Pull requests should be required") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/require-signed-commits.py
+++ b/policies/vcs/require-signed-commits.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-signed-commits", "Signed commits should be required") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 

--- a/policies/vcs/require-status-checks.py
+++ b/policies/vcs/require-status-checks.py
@@ -3,6 +3,9 @@ from lunar_policy import Check
 
 def main():
     with Check("require-status-checks", "Status checks should be required") as c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 


### PR DESCRIPTION
## Summary

All VCS policies now use `assert_exists()` to check for required data before accessing it. This prevents crashes when the github collector hasn't run and provides clear error messages.

## Problem

Previously, when the VCS policy was run against a component without VCS data (e.g., when the github collector hadn't run), the policies would crash with:

```
ValueError: No data found at path .vcs.branch_protection.enabled
```

## Solution

Added `assert_exists()` checks at the start of each policy to gracefully handle missing data:

```python
c.assert_exists(".vcs.branch_protection", 
    "VCS data not found. Ensure the github collector is configured and has run.")
```

This results in a clear failure message in the UI instead of a crash.

## Testing

Tested with Docker container using mock component JSON:
- Without VCS data: policies fail gracefully with clear message
- With VCS data: policies pass/fail as expected

---
*This PR was drafted by AI.*