### PR TITLE
Add unit tests for VCS policies

### DIFF
--- a/policies/vcs/allowed-merge-strategies.py
+++ b/policies/vcs/allowed-merge-strategies.py
@@ -1,9 +1,13 @@
 from lunar_policy import Check, variable_or_default
 
 
-def main():
-    with Check("allowed-merge-strategies", "Merge strategies should match allowed list") as c:
-        allowed_merge_strategies = variable_or_default("allowed_merge_strategies", "")
+def main(node=None, allowed_strategies_override=None):
+    c = Check("allowed-merge-strategies", "Merge strategies should match allowed list", node=node)
+    with c:
+        c.assert_exists(".vcs.merge_strategies", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
+        allowed_merge_strategies = allowed_strategies_override if allowed_strategies_override is not None else variable_or_default("allowed_merge_strategies", "")
         allowed_list = [s.strip().lower() for s in allowed_merge_strategies.split(",") if s.strip()]
 
         # Validate configuration
@@ -38,6 +42,7 @@ def main():
                 }[strategy_name]
 
                 c.assert_false(is_enabled, f"{strategy_display} are enabled, but policy does not allow them (should be disabled)")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/branch-protection-enabled.py
+++ b/policies/vcs/branch-protection-enabled.py
@@ -1,12 +1,17 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("branch-protection-enabled", "Branch protection should be enabled") as c:
+def main(node=None):
+    c = Check("branch-protection-enabled", "Branch protection should be enabled", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         branch = c.get_value_or_default(".vcs.branch_protection.branch", "default branch")
 
         c.assert_true(enabled, f"Branch protection is not enabled on {branch}")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/disallow-branch-deletion.py
+++ b/policies/vcs/disallow-branch-deletion.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("disallow-branch-deletion", "Branch deletions should be disallowed") as c:
+def main(node=None):
+    c = Check("disallow-branch-deletion", "Branch deletions should be disallowed", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         allow_deletions = c.get_value(".vcs.branch_protection.allow_deletions")
         c.assert_false(allow_deletions, "Branch protection allows branch deletion, but policy requires it to be disabled")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/disallow-force-push.py
+++ b/policies/vcs/disallow-force-push.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("disallow-force-push", "Force pushes should be disallowed") as c:
+def main(node=None):
+    c = Check("disallow-force-push", "Force pushes should be disallowed", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         allow_force_push = c.get_value(".vcs.branch_protection.allow_force_push")
         c.assert_false(allow_force_push, "Branch protection allows force pushes, but policy requires them to be disabled")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/dismiss-stale-reviews.py
+++ b/policies/vcs/dismiss-stale-reviews.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("dismiss-stale-reviews", "Stale reviews should be dismissed") as c:
+def main(node=None):
+    c = Check("dismiss-stale-reviews", "Stale reviews should be dismissed", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         dismiss_stale_reviews = c.get_value(".vcs.branch_protection.dismiss_stale_reviews")
         c.assert_true(dismiss_stale_reviews, "Branch protection does not dismiss stale reviews when new commits are pushed")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/minimum-approvals.py
+++ b/policies/vcs/minimum-approvals.py
@@ -1,12 +1,16 @@
 from lunar_policy import Check, variable_or_default
 
 
-def main():
-    with Check("minimum-approvals", "Pull requests should require minimum number of approvals") as c:
+def main(node=None, min_approvals_override=None):
+    c = Check("minimum-approvals", "Pull requests should require minimum number of approvals", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
-        min_approvals = variable_or_default("min_approvals", None)
+        min_approvals = min_approvals_override if min_approvals_override is not None else variable_or_default("min_approvals", None)
         if min_approvals is None:
             raise ValueError("Policy misconfiguration: min_approvals must be configured")
 
@@ -22,6 +26,7 @@ def main():
             f"Branch protection requires {required_approvals} approval(s), "
             f"but policy requires at least {min_approvals}"
         )
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-branches-up-to-date.py
+++ b/policies/vcs/require-branches-up-to-date.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-branches-up-to-date", "Branches should be required to be up to date") as c:
+def main(node=None):
+    c = Check("require-branches-up-to-date", "Branches should be required to be up to date", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         require_branches_up_to_date = c.get_value(".vcs.branch_protection.require_branches_up_to_date")
         c.assert_true(require_branches_up_to_date, "Branch protection does not require branches to be up to date before merging")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-codeowner-review.py
+++ b/policies/vcs/require-codeowner-review.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-codeowner-review", "Code owner review should be required") as c:
+def main(node=None):
+    c = Check("require-codeowner-review", "Code owner review should be required", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         require_codeowner_review = c.get_value(".vcs.branch_protection.require_codeowner_review")
         c.assert_true(require_codeowner_review, "Branch protection does not require code owner review")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-default-branch.py
+++ b/policies/vcs/require-default-branch.py
@@ -1,12 +1,17 @@
 from lunar_policy import Check, variable_or_default
 
 
-def main():
-    with Check("require-default-branch", "Default branch should match required name") as c:
+def main(node=None):
+    c = Check("require-default-branch", "Default branch should match required name", node=node)
+    with c:
+        c.assert_exists(".vcs.default_branch", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         required_default_branch = variable_or_default("required_default_branch", "main")
         default_branch = c.get_value(".vcs.default_branch")
 
-        c.assert_equal(default_branch, required_default_branch, f"Default branch is '{default_branch}', but policy requires '{required_default_branch}'")
+        c.assert_equals(default_branch, required_default_branch, f"Default branch is '{default_branch}', but policy requires '{required_default_branch}'")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-linear-history.py
+++ b/policies/vcs/require-linear-history.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-linear-history", "Linear history should be required") as c:
+def main(node=None):
+    c = Check("require-linear-history", "Linear history should be required", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         require_linear_history = c.get_value(".vcs.branch_protection.require_linear_history")
         c.assert_true(require_linear_history, "Branch protection does not require linear history")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-private.py
+++ b/policies/vcs/require-private.py
@@ -1,10 +1,15 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-private", "Repository must be private") as c:
+def main(node=None):
+    c = Check("require-private", "Repository must be private", node=node)
+    with c:
+        c.assert_exists(".vcs.visibility", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         visibility = c.get_value(".vcs.visibility")
-        c.assert_equal(visibility, "private", f"Repository visibility is '{visibility}', but policy requires 'private'")
+        c.assert_equals(visibility, "private", f"Repository visibility is '{visibility}', but policy requires 'private'")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-pull-request.py
+++ b/policies/vcs/require-pull-request.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-pull-request", "Pull requests should be required") as c:
+def main(node=None):
+    c = Check("require-pull-request", "Pull requests should be required", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         require_pr = c.get_value(".vcs.branch_protection.require_pr")
         c.assert_true(require_pr, "Branch protection does not require pull requests before merging")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-signed-commits.py
+++ b/policies/vcs/require-signed-commits.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-signed-commits", "Signed commits should be required") as c:
+def main(node=None):
+    c = Check("require-signed-commits", "Signed commits should be required", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         require_signed_commits = c.get_value(".vcs.branch_protection.require_signed_commits")
         c.assert_true(require_signed_commits, "Branch protection does not require signed commits")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/require-status-checks.py
+++ b/policies/vcs/require-status-checks.py
@@ -1,13 +1,18 @@
 from lunar_policy import Check
 
 
-def main():
-    with Check("require-status-checks", "Status checks should be required") as c:
+def main(node=None):
+    c = Check("require-status-checks", "Status checks should be required", node=node)
+    with c:
+        c.assert_exists(".vcs.branch_protection", 
+            "VCS data not found. Ensure the github collector is configured and has run.")
+        
         enabled = c.get_value(".vcs.branch_protection.enabled")
         c.assert_true(enabled, "Branch protection is not enabled")
 
         require_status_checks = c.get_value(".vcs.branch_protection.require_status_checks")
         c.assert_true(require_status_checks, "Branch protection does not require status checks to pass")
+    return c
 
 
 if __name__ == "__main__":

--- a/policies/vcs/test_vcs_policies.py
+++ b/policies/vcs/test_vcs_policies.py
@@ -1,0 +1,447 @@
+"""Unit tests for VCS policies.
+
+These tests verify that the VCS policies correctly evaluate branch protection
+settings and repository configuration. The tests help catch issues like:
+- Typos in SDK method names (e.g., assert_equal vs assert_equals)
+- Missing data handling
+- Logic errors in policy assertions
+"""
+
+import unittest
+from lunar_policy import Node, CheckStatus
+
+# Import all policy main functions
+# Note: Python files have hyphens in names, use importlib for clean imports
+import importlib.util
+import sys
+from pathlib import Path
+
+def load_policy(filename):
+    """Load a policy module from a hyphenated filename."""
+    policy_dir = Path(__file__).parent
+    spec = importlib.util.spec_from_file_location(
+        filename.replace("-", "_"), 
+        policy_dir / f"{filename}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.main
+
+check_branch_protection_enabled = load_policy("branch-protection-enabled")
+check_disallow_branch_deletion = load_policy("disallow-branch-deletion")
+check_disallow_force_push = load_policy("disallow-force-push")
+check_dismiss_stale_reviews = load_policy("dismiss-stale-reviews")
+check_require_branches_up_to_date = load_policy("require-branches-up-to-date")
+check_require_codeowner_review = load_policy("require-codeowner-review")
+check_require_linear_history = load_policy("require-linear-history")
+check_require_pull_request = load_policy("require-pull-request")
+check_require_signed_commits = load_policy("require-signed-commits")
+check_require_status_checks = load_policy("require-status-checks")
+check_require_private = load_policy("require-private")
+check_require_default_branch = load_policy("require-default-branch")
+check_minimum_approvals = load_policy("minimum-approvals")
+check_allowed_merge_strategies = load_policy("allowed-merge-strategies")
+
+
+def make_branch_protection_data(
+    enabled=True,
+    branch="main",
+    allow_deletions=False,
+    allow_force_push=False,
+    dismiss_stale_reviews=True,
+    require_branches_up_to_date=True,
+    require_codeowner_review=True,
+    require_linear_history=True,
+    require_pr=True,
+    require_signed_commits=True,
+    require_status_checks=True,
+    required_approvals=2,
+):
+    """Helper to create branch protection test data."""
+    return {
+        "vcs": {
+            "branch_protection": {
+                "enabled": enabled,
+                "branch": branch,
+                "allow_deletions": allow_deletions,
+                "allow_force_push": allow_force_push,
+                "dismiss_stale_reviews": dismiss_stale_reviews,
+                "require_branches_up_to_date": require_branches_up_to_date,
+                "require_codeowner_review": require_codeowner_review,
+                "require_linear_history": require_linear_history,
+                "require_pr": require_pr,
+                "require_signed_commits": require_signed_commits,
+                "require_status_checks": require_status_checks,
+                "required_approvals": required_approvals,
+            }
+        }
+    }
+
+
+class TestBranchProtectionEnabled(unittest.TestCase):
+    """Tests for branch-protection-enabled policy."""
+
+    def test_enabled_passes(self):
+        """Branch protection enabled should pass."""
+        data = make_branch_protection_data(enabled=True)
+        node = Node.from_component_json(data)
+        check = check_branch_protection_enabled(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_disabled_fails(self):
+        """Branch protection disabled should fail."""
+        data = make_branch_protection_data(enabled=False)
+        node = Node.from_component_json(data)
+        check = check_branch_protection_enabled(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
+
+    def test_missing_data_fails(self):
+        """Missing VCS data should fail with clear message."""
+        data = {}
+        node = Node.from_component_json(data)
+        check = check_branch_protection_enabled(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("VCS data not found", check.failure_reasons[0])
+
+
+class TestDisallowBranchDeletion(unittest.TestCase):
+    """Tests for disallow-branch-deletion policy."""
+
+    def test_deletions_disallowed_passes(self):
+        """Branch deletions disallowed should pass."""
+        data = make_branch_protection_data(allow_deletions=False)
+        node = Node.from_component_json(data)
+        check = check_disallow_branch_deletion(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_deletions_allowed_fails(self):
+        """Branch deletions allowed should fail."""
+        data = make_branch_protection_data(allow_deletions=True)
+        node = Node.from_component_json(data)
+        check = check_disallow_branch_deletion(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("deletion", check.failure_reasons[0].lower())
+
+    def test_protection_disabled_fails(self):
+        """Disabled branch protection should fail."""
+        data = make_branch_protection_data(enabled=False, allow_deletions=False)
+        node = Node.from_component_json(data)
+        check = check_disallow_branch_deletion(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestDisallowForcePush(unittest.TestCase):
+    """Tests for disallow-force-push policy."""
+
+    def test_force_push_disallowed_passes(self):
+        """Force push disallowed should pass."""
+        data = make_branch_protection_data(allow_force_push=False)
+        node = Node.from_component_json(data)
+        check = check_disallow_force_push(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_force_push_allowed_fails(self):
+        """Force push allowed should fail."""
+        data = make_branch_protection_data(allow_force_push=True)
+        node = Node.from_component_json(data)
+        check = check_disallow_force_push(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("force push", check.failure_reasons[0].lower())
+
+
+class TestDismissStaleReviews(unittest.TestCase):
+    """Tests for dismiss-stale-reviews policy."""
+
+    def test_stale_reviews_dismissed_passes(self):
+        """Stale reviews dismissed should pass."""
+        data = make_branch_protection_data(dismiss_stale_reviews=True)
+        node = Node.from_component_json(data)
+        check = check_dismiss_stale_reviews(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_stale_reviews_not_dismissed_fails(self):
+        """Stale reviews not dismissed should fail."""
+        data = make_branch_protection_data(dismiss_stale_reviews=False)
+        node = Node.from_component_json(data)
+        check = check_dismiss_stale_reviews(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("stale review", check.failure_reasons[0].lower())
+
+
+class TestRequireBranchesUpToDate(unittest.TestCase):
+    """Tests for require-branches-up-to-date policy."""
+
+    def test_branches_up_to_date_required_passes(self):
+        """Branches up to date required should pass."""
+        data = make_branch_protection_data(require_branches_up_to_date=True)
+        node = Node.from_component_json(data)
+        check = check_require_branches_up_to_date(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_branches_up_to_date_not_required_fails(self):
+        """Branches up to date not required should fail."""
+        data = make_branch_protection_data(require_branches_up_to_date=False)
+        node = Node.from_component_json(data)
+        check = check_require_branches_up_to_date(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestRequireCodeownerReview(unittest.TestCase):
+    """Tests for require-codeowner-review policy."""
+
+    def test_codeowner_review_required_passes(self):
+        """Code owner review required should pass."""
+        data = make_branch_protection_data(require_codeowner_review=True)
+        node = Node.from_component_json(data)
+        check = check_require_codeowner_review(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_codeowner_review_not_required_fails(self):
+        """Code owner review not required should fail."""
+        data = make_branch_protection_data(require_codeowner_review=False)
+        node = Node.from_component_json(data)
+        check = check_require_codeowner_review(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestRequireLinearHistory(unittest.TestCase):
+    """Tests for require-linear-history policy."""
+
+    def test_linear_history_required_passes(self):
+        """Linear history required should pass."""
+        data = make_branch_protection_data(require_linear_history=True)
+        node = Node.from_component_json(data)
+        check = check_require_linear_history(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_linear_history_not_required_fails(self):
+        """Linear history not required should fail."""
+        data = make_branch_protection_data(require_linear_history=False)
+        node = Node.from_component_json(data)
+        check = check_require_linear_history(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestRequirePullRequest(unittest.TestCase):
+    """Tests for require-pull-request policy."""
+
+    def test_pr_required_passes(self):
+        """PR required should pass."""
+        data = make_branch_protection_data(require_pr=True)
+        node = Node.from_component_json(data)
+        check = check_require_pull_request(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_pr_not_required_fails(self):
+        """PR not required should fail."""
+        data = make_branch_protection_data(require_pr=False)
+        node = Node.from_component_json(data)
+        check = check_require_pull_request(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestRequireSignedCommits(unittest.TestCase):
+    """Tests for require-signed-commits policy."""
+
+    def test_signed_commits_required_passes(self):
+        """Signed commits required should pass."""
+        data = make_branch_protection_data(require_signed_commits=True)
+        node = Node.from_component_json(data)
+        check = check_require_signed_commits(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_signed_commits_not_required_fails(self):
+        """Signed commits not required should fail."""
+        data = make_branch_protection_data(require_signed_commits=False)
+        node = Node.from_component_json(data)
+        check = check_require_signed_commits(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestRequireStatusChecks(unittest.TestCase):
+    """Tests for require-status-checks policy."""
+
+    def test_status_checks_required_passes(self):
+        """Status checks required should pass."""
+        data = make_branch_protection_data(require_status_checks=True)
+        node = Node.from_component_json(data)
+        check = check_require_status_checks(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_status_checks_not_required_fails(self):
+        """Status checks not required should fail."""
+        data = make_branch_protection_data(require_status_checks=False)
+        node = Node.from_component_json(data)
+        check = check_require_status_checks(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+
+
+class TestRequirePrivate(unittest.TestCase):
+    """Tests for require-private policy."""
+
+    def test_private_repo_passes(self):
+        """Private repository should pass."""
+        data = {"vcs": {"visibility": "private"}}
+        node = Node.from_component_json(data)
+        check = check_require_private(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_public_repo_fails(self):
+        """Public repository should fail."""
+        data = {"vcs": {"visibility": "public"}}
+        node = Node.from_component_json(data)
+        check = check_require_private(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("public", check.failure_reasons[0])
+        self.assertIn("private", check.failure_reasons[0])
+
+    def test_missing_visibility_fails(self):
+        """Missing visibility data should fail."""
+        data = {}
+        node = Node.from_component_json(data)
+        check = check_require_private(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("VCS data not found", check.failure_reasons[0])
+
+
+class TestRequireDefaultBranch(unittest.TestCase):
+    """Tests for require-default-branch policy."""
+
+    def test_main_branch_passes(self):
+        """Default branch 'main' should pass with default config."""
+        data = {"vcs": {"default_branch": "main"}}
+        node = Node.from_component_json(data)
+        check = check_require_default_branch(node)
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_master_branch_fails(self):
+        """Default branch 'master' should fail with default config."""
+        data = {"vcs": {"default_branch": "master"}}
+        node = Node.from_component_json(data)
+        check = check_require_default_branch(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("master", check.failure_reasons[0])
+        self.assertIn("main", check.failure_reasons[0])
+
+
+class TestMinimumApprovals(unittest.TestCase):
+    """Tests for minimum-approvals policy."""
+
+    def test_enough_approvals_passes(self):
+        """Enough required approvals should pass."""
+        data = make_branch_protection_data(required_approvals=2)
+        node = Node.from_component_json(data)
+        check = check_minimum_approvals(node, min_approvals_override="2")
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_more_than_minimum_passes(self):
+        """More than minimum approvals should pass."""
+        data = make_branch_protection_data(required_approvals=3)
+        node = Node.from_component_json(data)
+        check = check_minimum_approvals(node, min_approvals_override="2")
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_less_than_minimum_fails(self):
+        """Less than minimum approvals should fail."""
+        data = make_branch_protection_data(required_approvals=1)
+        node = Node.from_component_json(data)
+        check = check_minimum_approvals(node, min_approvals_override="2")
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("1", check.failure_reasons[0])
+        self.assertIn("2", check.failure_reasons[0])
+
+    def test_misconfiguration_raises_error(self):
+        """Missing min_approvals config should raise ValueError."""
+        data = make_branch_protection_data(required_approvals=2)
+        node = Node.from_component_json(data)
+        with self.assertRaises(ValueError) as context:
+            check_minimum_approvals(node, min_approvals_override=None)
+        self.assertIn("misconfiguration", str(context.exception))
+
+
+class TestAllowedMergeStrategies(unittest.TestCase):
+    """Tests for allowed-merge-strategies policy."""
+
+    def test_only_squash_allowed_passes(self):
+        """Only squash enabled when only squash allowed should pass."""
+        data = {
+            "vcs": {
+                "merge_strategies": {
+                    "allow_merge_commit": False,
+                    "allow_squash_merge": True,
+                    "allow_rebase_merge": False,
+                }
+            }
+        }
+        node = Node.from_component_json(data)
+        check = check_allowed_merge_strategies(node, allowed_strategies_override="squash")
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_disallowed_strategy_enabled_fails(self):
+        """Disallowed strategy enabled should fail."""
+        data = {
+            "vcs": {
+                "merge_strategies": {
+                    "allow_merge_commit": True,  # Not allowed
+                    "allow_squash_merge": True,
+                    "allow_rebase_merge": False,
+                }
+            }
+        }
+        node = Node.from_component_json(data)
+        check = check_allowed_merge_strategies(node, allowed_strategies_override="squash")
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("Merge commits", check.failure_reasons[0])
+
+    def test_multiple_allowed_strategies_pass(self):
+        """Multiple allowed strategies with only those enabled should pass."""
+        data = {
+            "vcs": {
+                "merge_strategies": {
+                    "allow_merge_commit": False,
+                    "allow_squash_merge": True,
+                    "allow_rebase_merge": True,
+                }
+            }
+        }
+        node = Node.from_component_json(data)
+        check = check_allowed_merge_strategies(node, allowed_strategies_override="squash,rebase")
+        self.assertEqual(check.status, CheckStatus.PASS)
+
+    def test_invalid_strategy_raises_error(self):
+        """Invalid strategy in config should raise ValueError."""
+        data = {
+            "vcs": {
+                "merge_strategies": {
+                    "allow_merge_commit": False,
+                    "allow_squash_merge": True,
+                    "allow_rebase_merge": False,
+                }
+            }
+        }
+        node = Node.from_component_json(data)
+        with self.assertRaises(ValueError) as context:
+            check_allowed_merge_strategies(node, allowed_strategies_override="invalid")
+        self.assertIn("Invalid merge strategies", str(context.exception))
+
+    def test_empty_config_raises_error(self):
+        """Empty allowed_merge_strategies should raise ValueError."""
+        data = {
+            "vcs": {
+                "merge_strategies": {
+                    "allow_merge_commit": True,
+                    "allow_squash_merge": True,
+                    "allow_rebase_merge": True,
+                }
+            }
+        }
+        node = Node.from_component_json(data)
+        with self.assertRaises(ValueError) as context:
+            check_allowed_merge_strategies(node, allowed_strategies_override="")
+        self.assertIn("must be configured", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
VCS policies were crashing with unhandled exceptions when the GitHub collector hadn't run. Now they handle missing data gracefully by reporting a clear policy failure instead of crashing.

Also adds unit test coverage to catch issues like this before deployment.

## Problem
When VCS data wasn't available (e.g., GitHub collector not configured or not yet run), policies would crash with:
```
ValueError: No data found at path .vcs.branch_protection.enabled
```

This resulted in an `error` status instead of a meaningful failure message.

## Solution
- Added `c.assert_exists(".vcs.branch_protection", ...)` at the start of each policy
- Now policies fail gracefully with a clear message: "VCS data not found. Ensure the github collector is configured and has run."
- Also fixed `assert_equal` → `assert_equals` typo in two policies

## Unit Tests
Added `test_vcs_policies.py` with comprehensive tests covering:
- Pass cases with valid data  
- Fail cases (e.g., branch protection disabled)
- Missing data handling (verifies `assert_exists` works correctly)
- Configuration error cases

Tests ensure the full logic path executes, catching SDK method typos and logic errors before deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced VCS policy validations with improved error messaging when VCS data is unavailable, making troubleshooting easier.
  * Policies now include explicit checks to detect missing configurations and provide clear guidance on required setup.

* **Tests**
  * Added comprehensive test coverage for all VCS policy checks, validating behavior across various configurations and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->