### PR TITLE
Fix VCS policies to handle disabled branch protection gracefully

### DIFF
--- a/policies/vcs/disallow-branch-deletion.py
+++ b/policies/vcs/disallow-branch-deletion.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        allow_deletions = c.get_value(".vcs.branch_protection.allow_deletions")
-        c.assert_false(allow_deletions, "Branch protection allows branch deletion, but policy requires it to be disabled")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            allow_deletions = c.get_value(".vcs.branch_protection.allow_deletions")
+            c.assert_false(allow_deletions, "Branch protection allows branch deletion, but policy requires it to be disabled")
     return c
 
 

--- a/policies/vcs/disallow-force-push.py
+++ b/policies/vcs/disallow-force-push.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        allow_force_push = c.get_value(".vcs.branch_protection.allow_force_push")
-        c.assert_false(allow_force_push, "Branch protection allows force pushes, but policy requires them to be disabled")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            allow_force_push = c.get_value(".vcs.branch_protection.allow_force_push")
+            c.assert_false(allow_force_push, "Branch protection allows force pushes, but policy requires them to be disabled")
     return c
 
 

--- a/policies/vcs/dismiss-stale-reviews.py
+++ b/policies/vcs/dismiss-stale-reviews.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        dismiss_stale_reviews = c.get_value(".vcs.branch_protection.dismiss_stale_reviews")
-        c.assert_true(dismiss_stale_reviews, "Branch protection does not dismiss stale reviews when new commits are pushed")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            dismiss_stale_reviews = c.get_value(".vcs.branch_protection.dismiss_stale_reviews")
+            c.assert_true(dismiss_stale_reviews, "Branch protection does not dismiss stale reviews when new commits are pushed")
     return c
 
 

--- a/policies/vcs/minimum-approvals.py
+++ b/policies/vcs/minimum-approvals.py
@@ -8,24 +8,25 @@ def main(node=None, min_approvals_override=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            min_approvals = min_approvals_override if min_approvals_override is not None else variable_or_default("min_approvals", None)
+            if min_approvals is None:
+                raise ValueError("Policy misconfiguration: min_approvals must be configured")
 
-        min_approvals = min_approvals_override if min_approvals_override is not None else variable_or_default("min_approvals", None)
-        if min_approvals is None:
-            raise ValueError("Policy misconfiguration: min_approvals must be configured")
+            try:
+                min_approvals = int(min_approvals)
+            except (ValueError, TypeError):
+                raise ValueError(f"Policy misconfiguration: min_approvals must be a number, got: {min_approvals}")
 
-        try:
-            min_approvals = int(min_approvals)
-        except (ValueError, TypeError):
-            raise ValueError(f"Policy misconfiguration: min_approvals must be a number, got: {min_approvals}")
-
-        required_approvals = c.get_value(".vcs.branch_protection.required_approvals")
-        c.assert_greater_or_equal(
-            required_approvals,
-            min_approvals,
-            f"Branch protection requires {required_approvals} approval(s), "
-            f"but policy requires at least {min_approvals}"
-        )
+            required_approvals = c.get_value(".vcs.branch_protection.required_approvals")
+            c.assert_greater_or_equal(
+                required_approvals,
+                min_approvals,
+                f"Branch protection requires {required_approvals} approval(s), "
+                f"but policy requires at least {min_approvals}"
+            )
     return c
 
 

--- a/policies/vcs/require-branches-up-to-date.py
+++ b/policies/vcs/require-branches-up-to-date.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        require_branches_up_to_date = c.get_value(".vcs.branch_protection.require_branches_up_to_date")
-        c.assert_true(require_branches_up_to_date, "Branch protection does not require branches to be up to date before merging")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            require_branches_up_to_date = c.get_value(".vcs.branch_protection.require_branches_up_to_date")
+            c.assert_true(require_branches_up_to_date, "Branch protection does not require branches to be up to date before merging")
     return c
 
 

--- a/policies/vcs/require-codeowner-review.py
+++ b/policies/vcs/require-codeowner-review.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        require_codeowner_review = c.get_value(".vcs.branch_protection.require_codeowner_review")
-        c.assert_true(require_codeowner_review, "Branch protection does not require code owner review")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            require_codeowner_review = c.get_value(".vcs.branch_protection.require_codeowner_review")
+            c.assert_true(require_codeowner_review, "Branch protection does not require code owner review")
     return c
 
 

--- a/policies/vcs/require-linear-history.py
+++ b/policies/vcs/require-linear-history.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        require_linear_history = c.get_value(".vcs.branch_protection.require_linear_history")
-        c.assert_true(require_linear_history, "Branch protection does not require linear history")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            require_linear_history = c.get_value(".vcs.branch_protection.require_linear_history")
+            c.assert_true(require_linear_history, "Branch protection does not require linear history")
     return c
 
 

--- a/policies/vcs/require-pull-request.py
+++ b/policies/vcs/require-pull-request.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        require_pr = c.get_value(".vcs.branch_protection.require_pr")
-        c.assert_true(require_pr, "Branch protection does not require pull requests before merging")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            require_pr = c.get_value(".vcs.branch_protection.require_pr")
+            c.assert_true(require_pr, "Branch protection does not require pull requests before merging")
     return c
 
 

--- a/policies/vcs/require-signed-commits.py
+++ b/policies/vcs/require-signed-commits.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        require_signed_commits = c.get_value(".vcs.branch_protection.require_signed_commits")
-        c.assert_true(require_signed_commits, "Branch protection does not require signed commits")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            require_signed_commits = c.get_value(".vcs.branch_protection.require_signed_commits")
+            c.assert_true(require_signed_commits, "Branch protection does not require signed commits")
     return c
 
 

--- a/policies/vcs/require-status-checks.py
+++ b/policies/vcs/require-status-checks.py
@@ -8,10 +8,11 @@ def main(node=None):
             "VCS data not found. Ensure the github collector is configured and has run.")
         
         enabled = c.get_value(".vcs.branch_protection.enabled")
-        c.assert_true(enabled, "Branch protection is not enabled")
-
-        require_status_checks = c.get_value(".vcs.branch_protection.require_status_checks")
-        c.assert_true(require_status_checks, "Branch protection does not require status checks to pass")
+        if not enabled:
+            c.fail("Branch protection is not enabled")
+        else:
+            require_status_checks = c.get_value(".vcs.branch_protection.require_status_checks")
+            c.assert_true(require_status_checks, "Branch protection does not require status checks to pass")
     return c
 
 

--- a/policies/vcs/test_vcs_policies.py
+++ b/policies/vcs/test_vcs_policies.py
@@ -79,6 +79,22 @@ def make_branch_protection_data(
     }
 
 
+def make_disabled_protection_data(branch="main"):
+    """Helper to create disabled branch protection data.
+    
+    When branch protection is disabled, GitHub only returns enabled/branch
+    without the detailed settings. This tests the real-world scenario.
+    """
+    return {
+        "vcs": {
+            "branch_protection": {
+                "enabled": False,
+                "branch": branch,
+            }
+        }
+    }
+
+
 class TestBranchProtectionEnabled(unittest.TestCase):
     """Tests for branch-protection-enabled policy."""
 
@@ -131,6 +147,14 @@ class TestDisallowBranchDeletion(unittest.TestCase):
         check = check_disallow_branch_deletion(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
 
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_disallow_branch_deletion(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
+
 
 class TestDisallowForcePush(unittest.TestCase):
     """Tests for disallow-force-push policy."""
@@ -149,6 +173,14 @@ class TestDisallowForcePush(unittest.TestCase):
         check = check_disallow_force_push(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
         self.assertIn("force push", check.failure_reasons[0].lower())
+
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_disallow_force_push(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
 
 
 class TestDismissStaleReviews(unittest.TestCase):
@@ -169,6 +201,14 @@ class TestDismissStaleReviews(unittest.TestCase):
         self.assertEqual(check.status, CheckStatus.FAIL)
         self.assertIn("stale review", check.failure_reasons[0].lower())
 
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_dismiss_stale_reviews(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
+
 
 class TestRequireBranchesUpToDate(unittest.TestCase):
     """Tests for require-branches-up-to-date policy."""
@@ -186,6 +226,14 @@ class TestRequireBranchesUpToDate(unittest.TestCase):
         node = Node.from_component_json(data)
         check = check_require_branches_up_to_date(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
+
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_require_branches_up_to_date(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
 
 
 class TestRequireCodeownerReview(unittest.TestCase):
@@ -205,6 +253,14 @@ class TestRequireCodeownerReview(unittest.TestCase):
         check = check_require_codeowner_review(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
 
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_require_codeowner_review(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
+
 
 class TestRequireLinearHistory(unittest.TestCase):
     """Tests for require-linear-history policy."""
@@ -222,6 +278,14 @@ class TestRequireLinearHistory(unittest.TestCase):
         node = Node.from_component_json(data)
         check = check_require_linear_history(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
+
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_require_linear_history(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
 
 
 class TestRequirePullRequest(unittest.TestCase):
@@ -241,6 +305,14 @@ class TestRequirePullRequest(unittest.TestCase):
         check = check_require_pull_request(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
 
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_require_pull_request(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
+
 
 class TestRequireSignedCommits(unittest.TestCase):
     """Tests for require-signed-commits policy."""
@@ -259,6 +331,14 @@ class TestRequireSignedCommits(unittest.TestCase):
         check = check_require_signed_commits(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
 
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_require_signed_commits(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
+
 
 class TestRequireStatusChecks(unittest.TestCase):
     """Tests for require-status-checks policy."""
@@ -276,6 +356,14 @@ class TestRequireStatusChecks(unittest.TestCase):
         node = Node.from_component_json(data)
         check = check_require_status_checks(node)
         self.assertEqual(check.status, CheckStatus.FAIL)
+
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_require_status_checks(node)
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
 
 
 class TestRequirePrivate(unittest.TestCase):
@@ -359,6 +447,14 @@ class TestMinimumApprovals(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             check_minimum_approvals(node, min_approvals_override=None)
         self.assertIn("misconfiguration", str(context.exception))
+
+    def test_protection_disabled_minimal_data_fails(self):
+        """Disabled protection with minimal data should fail gracefully."""
+        data = make_disabled_protection_data()
+        node = Node.from_component_json(data)
+        check = check_minimum_approvals(node, min_approvals_override="2")
+        self.assertEqual(check.status, CheckStatus.FAIL)
+        self.assertIn("not enabled", check.failure_reasons[0])
 
 
 class TestAllowedMergeStrategies(unittest.TestCase):


### PR DESCRIPTION
## Problem

When branch protection is disabled, GitHub only returns `enabled: false` and `branch` fields - the detailed settings like `require_signed_commits`, `allow_force_push`, etc. are not present.

The previous fix (PR #20) added `assert_exists('.vcs.branch_protection')` which handles the case when VCS data is completely missing. However, when branch protection **exists but is disabled**, the policy still crashes:

```
ValueError: No data found at path .vcs.branch_protection.require_signed_commits
```

This happens because:
1. `assert_exists('.vcs.branch_protection')` passes (data exists)
2. `assert_true(enabled)` fails (protection disabled), but **assertions don't stop execution**
3. Code continues and crashes trying to access nested fields that don't exist

## Solution

Use `if/else` to guard access to nested fields when `enabled` is False:

```python
enabled = c.get_value('.vcs.branch_protection.enabled')
if not enabled:
    c.fail('Branch protection is not enabled')
else:
    # Safe to access nested fields here
    require_signed_commits = c.get_value('.vcs.branch_protection.require_signed_commits')
    c.assert_true(require_signed_commits, ...)
```

## Changes

- Updated 9 VCS policies to use if/else pattern
- Added `make_disabled_protection_data()` test helper for minimal data scenario
- Added test cases for each policy covering the 'disabled protection with minimal data' case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for branch protection validation. Policies now provide explicit error messages when branch protection is disabled, instead of generic failures.

* **Tests**
  * Added validation tests across VCS policies to verify proper failure handling when branch protection is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->