### PR TITLE
Add ci-otel collector

### DIFF
--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -31,39 +31,6 @@ This plugin provides the following collectors:
 | `cmd-start` | Starts a span for each CI command under the current step |
 | `cmd-end` | Ends the command span with exit code and duration metadata |
 
-## Trace Structure
-
-A typical trace hierarchy looks like:
-
-```
-Job: github.com/acme/backend #123 abc1234 (root span)
-├── Step 0: Checkout (step span)
-│   ├── ["/usr/bin/git", "checkout", "--detach"]
-│   └── ["/usr/bin/git", "submodule", "status"]
-├── Step 1: Build (step span)
-│   └── ["/usr/bin/go", "build", "./..."]
-└── Step 2: Test (step span)
-    └── ["/usr/bin/go", "test", "-v", "./..."]
-```
-
-## Span Attributes
-
-All spans include:
-
-| Attribute | Description |
-|-----------|-------------|
-| `lunar.component_id` | Component identifier |
-| `lunar.pr` | Pull request number |
-| `lunar.git_sha` | Git commit SHA |
-| `lunar.domain` | Component domain |
-| `lunar.owner` | Component owner |
-| `ci.vendor` | CI vendor (e.g., "github-actions") |
-| `ci.span_type` | Span type: "job", "step", or "command" |
-| `ci.job_id` | CI job identifier |
-| `ci.job_name` | CI job name |
-
-Step and command spans include additional context-specific attributes.
-
 ## Installation
 
 Add to your `lunar-config.yml`:
@@ -76,9 +43,3 @@ collectors:
       otel_endpoint: "http://tempo:4318"  # Your OTLP HTTP endpoint
       # debug: "true"  # Enable to collect trace data in Component JSON
 ```
-
-## Requirements
-
-- An OTLP-compatible trace backend (Tempo, Jaeger, etc.)
-- Network access from CI runners to the OTLP endpoint
-- `jq` and `curl` available in the CI environment (provided by the default image)

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -1,0 +1,84 @@
+# CI OpenTelemetry Collector
+
+Emits OpenTelemetry traces for CI pipeline runs, providing detailed observability into job execution.
+
+## Overview
+
+This collector instruments CI pipelines with OpenTelemetry distributed tracing. It captures job, step, and command-level spans with timing and metadata, sending traces to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). This enables detailed visibility into CI performance, bottlenecks, and failures through your observability stack.
+
+## Collected Data
+
+This collector writes to the following Component JSON paths (when debug mode is enabled):
+
+| Path | Type | Description |
+|------|------|-------------|
+| `.ci.traces.{trace_id}` | object | Trace metadata including job, steps, and commands |
+| `.ci.traces.{trace_id}.steps.{step_index}` | object | Step-level timing and metadata |
+| `.ci.traces.{trace_id}.steps.{step_index}.commands.{cmd_hash}` | object | Command-level timing and process info |
+
+**Note:** The primary output is OpenTelemetry traces sent to the configured OTLP endpoint. Component JSON data is only collected when `debug: "true"` is set.
+
+## Collectors
+
+This plugin provides the following collectors:
+
+| Collector | Description |
+|-----------|-------------|
+| `job-start` | Starts the root span for the CI job, generates trace ID from component and job ID |
+| `job-end` | Ends the root span, calculates duration, sends the complete job span |
+| `step-start` | Starts a span for each CI step as a child of the job span |
+| `step-end` | Ends the step span, calculates duration, sends the complete step span |
+| `cmd-start` | Starts a span for each CI command under the current step |
+| `cmd-end` | Ends the command span with exit code and duration metadata |
+
+## Trace Structure
+
+A typical trace hierarchy looks like:
+
+```
+Job: github.com/acme/backend #123 abc1234 (root span)
+├── Step 0: Checkout (step span)
+│   ├── ["/usr/bin/git", "checkout", "--detach"]
+│   └── ["/usr/bin/git", "submodule", "status"]
+├── Step 1: Build (step span)
+│   └── ["/usr/bin/go", "build", "./..."]
+└── Step 2: Test (step span)
+    └── ["/usr/bin/go", "test", "-v", "./..."]
+```
+
+## Span Attributes
+
+All spans include:
+
+| Attribute | Description |
+|-----------|-------------|
+| `lunar.component_id` | Component identifier |
+| `lunar.pr` | Pull request number |
+| `lunar.git_sha` | Git commit SHA |
+| `lunar.domain` | Component domain |
+| `lunar.owner` | Component owner |
+| `ci.vendor` | CI vendor (e.g., "github-actions") |
+| `ci.span_type` | Span type: "job", "step", or "command" |
+| `ci.job_id` | CI job identifier |
+| `ci.job_name` | CI job name |
+
+Step and command spans include additional context-specific attributes.
+
+## Installation
+
+Add to your `lunar-config.yml`:
+
+```yaml
+collectors:
+  - uses: github://earthly/lunar-lib/collectors/ci-otel@v1.0.0
+    on: ["domain:your-domain"]
+    with:
+      otel_endpoint: "http://tempo:4318"  # Your OTLP HTTP endpoint
+      # debug: "true"  # Enable to collect trace data in Component JSON
+```
+
+## Requirements
+
+- An OTLP-compatible trace backend (Tempo, Jaeger, etc.)
+- Network access from CI runners to the OTLP endpoint
+- `jq` and `curl` available in the CI environment (provided by the default image)

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -4,11 +4,7 @@ Emits OpenTelemetry traces for CI pipeline runs, providing detailed observabilit
 
 ## Overview
 
-This collector instruments CI pipelines with OpenTelemetry distributed tracing. It captures job, step, and command-level spans with timing and metadata, sending traces to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.).
-
-**Performance note:** This collector runs natively on the CI runner (not in a container) because the hooks execute on every single command — containerization would add unacceptable overhead.
-
-**Dependencies:** Requires `jq` and `curl` to be available in your CI runner's environment. These are standard tools pre-installed on most CI runners (GitHub Actions, GitLab CI, CircleCI, etc.). Additionally, `xxd` is used as a fallback for span ID generation but is optional.
+This collector instruments CI pipelines with OpenTelemetry distributed tracing, capturing job, step, and command-level spans with timing and metadata. Traces are sent to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). Runs natively on the CI runner (not containerized) because hooks execute on every command—container overhead would be unacceptable. Requires `jq` and `curl` in your CI environment (pre-installed on most runners); `xxd` is optional.
 
 ## Collected Data
 

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -43,3 +43,4 @@ collectors:
       otel_endpoint: "http://tempo:4318"  # Your OTLP HTTP endpoint
       # debug: "true"  # Enable to collect trace data in Component JSON
 ```
+

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -4,7 +4,7 @@ Emits OpenTelemetry traces for CI pipeline runs, providing detailed observabilit
 
 ## Overview
 
-This collector instruments CI pipelines with OpenTelemetry distributed tracing. It captures job, step, and command-level spans with timing and metadata, sending traces to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). This enables detailed visibility into CI performance, bottlenecks, and failures through your observability stack.
+This collector instruments CI pipelines with OpenTelemetry distributed tracing. It captures job, step, and command-level spans with timing and metadata, sending traces to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). This collector runs natively on the CI runner (not in a container) for performance — hooks execute on every command. Requires `jq` and `curl` (pre-installed on GitHub Actions Ubuntu runners).
 
 ## Collected Data
 
@@ -43,20 +43,3 @@ collectors:
       otel_endpoint: "http://tempo:4318"  # Your OTLP HTTP endpoint
       # debug: "true"  # Enable to collect trace data in Component JSON
 ```
-
-## CI Runner Requirements
-
-This collector runs **natively** on the CI runner (not in a container) for performance reasons. CI hooks execute on every job, step, and command — container overhead would significantly slow down builds.
-
-The following tools must be available on the CI runner:
-
-| Tool | Required | Notes |
-|------|----------|-------|
-| `jq` | Yes | JSON processing for OTLP payloads |
-| `curl` | Yes | Sending traces to OTLP endpoint |
-| `sha256sum` | Yes | Trace ID generation (standard in coreutils) |
-| `date` | Yes | Timestamps (standard in coreutils) |
-
-**GitHub Actions:** Ubuntu runners (`ubuntu-latest`, `ubuntu-22.04`, `ubuntu-24.04`) have all required tools pre-installed.
-
-**Other CI systems:** Ensure `jq` and `curl` are available. Most Linux distributions include them or they can be installed via package manager.

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -4,7 +4,11 @@ Emits OpenTelemetry traces for CI pipeline runs, providing detailed observabilit
 
 ## Overview
 
-This collector instruments CI pipelines with OpenTelemetry distributed tracing. It captures job, step, and command-level spans with timing and metadata, sending traces to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). This collector runs natively on the CI runner (not in a container) for performance — hooks execute on every command. Requires `jq` and `curl` (pre-installed on GitHub Actions Ubuntu runners).
+This collector instruments CI pipelines with OpenTelemetry distributed tracing. It captures job, step, and command-level spans with timing and metadata, sending traces to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.).
+
+**Performance note:** This collector runs natively on the CI runner (not in a container) because the hooks execute on every single command — containerization would add unacceptable overhead.
+
+**Dependencies:** Requires `jq` and `curl` to be available in your CI runner's environment. These are standard tools pre-installed on most CI runners (GitHub Actions, GitLab CI, CircleCI, etc.). Additionally, `xxd` is used as a fallback for span ID generation but is optional.
 
 ## Collected Data
 

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -44,3 +44,19 @@ collectors:
       # debug: "true"  # Enable to collect trace data in Component JSON
 ```
 
+## CI Runner Requirements
+
+This collector runs **natively** on the CI runner (not in a container) for performance reasons. CI hooks execute on every job, step, and command — container overhead would significantly slow down builds.
+
+The following tools must be available on the CI runner:
+
+| Tool | Required | Notes |
+|------|----------|-------|
+| `jq` | Yes | JSON processing for OTLP payloads |
+| `curl` | Yes | Sending traces to OTLP endpoint |
+| `sha256sum` | Yes | Trace ID generation (standard in coreutils) |
+| `date` | Yes | Timestamps (standard in coreutils) |
+
+**GitHub Actions:** Ubuntu runners (`ubuntu-latest`, `ubuntu-22.04`, `ubuntu-24.04`) have all required tools pre-installed.
+
+**Other CI systems:** Ensure `jq` and `curl` are available. Most Linux distributions include them or they can be installed via package manager.

--- a/collectors/ci-otel/README.md
+++ b/collectors/ci-otel/README.md
@@ -4,7 +4,7 @@ Emits OpenTelemetry traces for CI pipeline runs, providing detailed observabilit
 
 ## Overview
 
-This collector instruments CI pipelines with OpenTelemetry distributed tracing, capturing job, step, and command-level spans with timing and metadata. Traces are sent to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). Runs natively on the CI runner (not containerized) because hooks execute on every command—container overhead would be unacceptable. Requires `jq` and `curl` in your CI environment (pre-installed on most runners); `xxd` is optional.
+This collector instruments CI pipelines with OpenTelemetry distributed tracing, capturing job, step, and command-level spans with timing and metadata. Traces are sent to any OTLP-compatible backend (Tempo, Jaeger, Honeycomb, etc.). Requires `jq` and `curl` in your CI environment (pre-installed on most runners); `xxd` is optional.
 
 ## Collected Data
 

--- a/collectors/ci-otel/assets/ci-otel.svg
+++ b/collectors/ci-otel/assets/ci-otel.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="8" fill="#1a1a2e"/>
+  <path d="M12 32 L20 24 L28 32 L36 20 L44 28 L52 16" stroke="#4cc9f0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="12" cy="32" r="3" fill="#f72585"/>
+  <circle cx="20" cy="24" r="3" fill="#f72585"/>
+  <circle cx="28" cy="32" r="3" fill="#f72585"/>
+  <circle cx="36" cy="20" r="3" fill="#f72585"/>
+  <circle cx="44" cy="28" r="3" fill="#f72585"/>
+  <circle cx="52" cy="16" r="3" fill="#f72585"/>
+  <path d="M16 44 L24 44 L24 52 L16 52 Z" fill="#7209b7"/>
+  <path d="M28 40 L36 40 L36 52 L28 52 Z" fill="#7209b7"/>
+  <path d="M40 36 L48 36 L48 52 L40 52 Z" fill="#7209b7"/>
+</svg>

--- a/collectors/ci-otel/assets/ci-otel.svg
+++ b/collectors/ci-otel/assets/ci-otel.svg
@@ -1,7 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <!-- CI badge in top-left corner (smaller) -->
-  <circle cx="15" cy="15" r="12" fill="#425cc7"/>
-  <text x="15" y="20" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">CI</text>
+  <defs>
+    <!-- Mask for CI cutout -->
+    <mask id="ci-cutout">
+      <circle cx="15" cy="15" r="12" fill="white"/>
+      <text x="15" y="20" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="black" text-anchor="middle">CI</text>
+    </mask>
+  </defs>
+  <!-- CI badge with cutout letters -->
+  <circle cx="15" cy="15" r="12" fill="#425cc7" mask="url(#ci-cutout)"/>
   <!-- OpenTelemetry official logo (centered) -->
   <g transform="translate(50, 52) scale(0.085) translate(-500, -500)">
     <path fill="#f5a800" d="M528.7 545.9c-42 42-42 110.1 0 152.1s110.1 42 152.1 0 42-110.1 0-152.1-110.1-42-152.1 0zm113.7 113.8c-20.8 20.8-54.5 20.8-75.3 0-20.8-20.8-20.8-54.5 0-75.3 20.8-20.8 54.5-20.8 75.3 0 20.8 20.7 20.8 54.5 0 75.3zm36.6-643l-65.9 65.9c-12.9 12.9-12.9 34.1 0 47l257.3 257.3c12.9 12.9 34.1 12.9 47 0l65.9-65.9c12.9-12.9 12.9-34.1 0-47L725.9 16.7c-12.9-12.9-34-12.9-46.9 0zM217.3 858.8c11.7-11.7 11.7-30.8 0-42.5l-33.5-33.5c-11.7-11.7-30.8-11.7-42.5 0L72.1 852l-.1.1-19-19c-10.5-10.5-27.6-10.5-38 0-10.5 10.5-10.5 27.6 0 38l114 114c10.5 10.5 27.6 10.5 38 0s10.5-27.6 0-38l-19-19 .1-.1 69.2-69.2z"/>

--- a/collectors/ci-otel/assets/ci-otel.svg
+++ b/collectors/ci-otel/assets/ci-otel.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <!-- CI text at top -->
-  <text x="50" y="16" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#425cc7" text-anchor="middle">CI</text>
-  <!-- OpenTelemetry official logo (scaled to fit below CI text) -->
-  <g transform="translate(5, 18) scale(0.09)">
+  <!-- CI badge in top-left corner (smaller) -->
+  <circle cx="15" cy="15" r="12" fill="#425cc7"/>
+  <text x="15" y="20" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">CI</text>
+  <!-- OpenTelemetry official logo (centered) -->
+  <g transform="translate(50, 52) scale(0.085) translate(-500, -500)">
     <path fill="#f5a800" d="M528.7 545.9c-42 42-42 110.1 0 152.1s110.1 42 152.1 0 42-110.1 0-152.1-110.1-42-152.1 0zm113.7 113.8c-20.8 20.8-54.5 20.8-75.3 0-20.8-20.8-20.8-54.5 0-75.3 20.8-20.8 54.5-20.8 75.3 0 20.8 20.7 20.8 54.5 0 75.3zm36.6-643l-65.9 65.9c-12.9 12.9-12.9 34.1 0 47l257.3 257.3c12.9 12.9 34.1 12.9 47 0l65.9-65.9c12.9-12.9 12.9-34.1 0-47L725.9 16.7c-12.9-12.9-34-12.9-46.9 0zM217.3 858.8c11.7-11.7 11.7-30.8 0-42.5l-33.5-33.5c-11.7-11.7-30.8-11.7-42.5 0L72.1 852l-.1.1-19-19c-10.5-10.5-27.6-10.5-38 0-10.5 10.5-10.5 27.6 0 38l114 114c10.5 10.5 27.6 10.5 38 0s10.5-27.6 0-38l-19-19 .1-.1 69.2-69.2z"/>
     <path fill="#425cc7" d="M565.9 205.9L419.5 352.3c-13 13-13 34.4 0 47.4l90.4 90.4c63.9-46 153.5-40.3 211 17.2l73.2-73.2c13-13 13-34.4 0-47.4L613.3 205.9c-13-13.1-34.4-13.1-47.4 0zm-94 322.3l-53.4-53.4c-12.5-12.5-33-12.5-45.5 0L184.7 663.2c-12.5 12.5-12.5 33 0 45.5l106.7 106.7c12.5 12.5 33 12.5 45.5 0L458 694.1c-25.6-52.9-21-116.8 13.9-165.9z"/>
   </g>

--- a/collectors/ci-otel/assets/ci-otel.svg
+++ b/collectors/ci-otel/assets/ci-otel.svg
@@ -1,13 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <rect width="64" height="64" rx="8" fill="#1a1a2e"/>
-  <path d="M12 32 L20 24 L28 32 L36 20 L44 28 L52 16" stroke="#4cc9f0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="12" cy="32" r="3" fill="#f72585"/>
-  <circle cx="20" cy="24" r="3" fill="#f72585"/>
-  <circle cx="28" cy="32" r="3" fill="#f72585"/>
-  <circle cx="36" cy="20" r="3" fill="#f72585"/>
-  <circle cx="44" cy="28" r="3" fill="#f72585"/>
-  <circle cx="52" cy="16" r="3" fill="#f72585"/>
-  <path d="M16 44 L24 44 L24 52 L16 52 Z" fill="#7209b7"/>
-  <path d="M28 40 L36 40 L36 52 L28 52 Z" fill="#7209b7"/>
-  <path d="M40 36 L48 36 L48 52 L40 52 Z" fill="#7209b7"/>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Trace visualization: horizontal overlapping spans -->
+  
+  <!-- Root span (job) - longest bar -->
+  <rect x="4" y="12" width="56" height="8" rx="2" fill="#ffffff"/>
+  
+  <!-- Step spans - medium bars, offset -->
+  <rect x="8" y="24" width="44" height="8" rx="2" fill="#a0a0a0"/>
+  <rect x="16" y="36" width="40" height="8" rx="2" fill="#a0a0a0"/>
+  
+  <!-- Command spans - shorter bars, more offset -->
+  <rect x="12" y="48" width="20" height="6" rx="1.5" fill="#606060"/>
+  <rect x="36" y="48" width="18" height="6" rx="1.5" fill="#606060"/>
 </svg>

--- a/collectors/ci-otel/assets/ci-otel.svg
+++ b/collectors/ci-otel/assets/ci-otel.svg
@@ -1,14 +1,9 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <!-- Trace visualization: horizontal overlapping spans -->
-  
-  <!-- Root span (job) - longest bar -->
-  <rect x="4" y="12" width="56" height="8" rx="2" fill="#ffffff"/>
-  
-  <!-- Step spans - medium bars, offset -->
-  <rect x="8" y="24" width="44" height="8" rx="2" fill="#a0a0a0"/>
-  <rect x="16" y="36" width="40" height="8" rx="2" fill="#a0a0a0"/>
-  
-  <!-- Command spans - shorter bars, more offset -->
-  <rect x="12" y="48" width="20" height="6" rx="1.5" fill="#606060"/>
-  <rect x="36" y="48" width="18" height="6" rx="1.5" fill="#606060"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- CI text at top -->
+  <text x="50" y="16" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#425cc7" text-anchor="middle">CI</text>
+  <!-- OpenTelemetry official logo (scaled to fit below CI text) -->
+  <g transform="translate(5, 18) scale(0.09)">
+    <path fill="#f5a800" d="M528.7 545.9c-42 42-42 110.1 0 152.1s110.1 42 152.1 0 42-110.1 0-152.1-110.1-42-152.1 0zm113.7 113.8c-20.8 20.8-54.5 20.8-75.3 0-20.8-20.8-20.8-54.5 0-75.3 20.8-20.8 54.5-20.8 75.3 0 20.8 20.7 20.8 54.5 0 75.3zm36.6-643l-65.9 65.9c-12.9 12.9-12.9 34.1 0 47l257.3 257.3c12.9 12.9 34.1 12.9 47 0l65.9-65.9c12.9-12.9 12.9-34.1 0-47L725.9 16.7c-12.9-12.9-34-12.9-46.9 0zM217.3 858.8c11.7-11.7 11.7-30.8 0-42.5l-33.5-33.5c-11.7-11.7-30.8-11.7-42.5 0L72.1 852l-.1.1-19-19c-10.5-10.5-27.6-10.5-38 0-10.5 10.5-10.5 27.6 0 38l114 114c10.5 10.5 27.6 10.5 38 0s10.5-27.6 0-38l-19-19 .1-.1 69.2-69.2z"/>
+    <path fill="#425cc7" d="M565.9 205.9L419.5 352.3c-13 13-13 34.4 0 47.4l90.4 90.4c63.9-46 153.5-40.3 211 17.2l73.2-73.2c13-13 13-34.4 0-47.4L613.3 205.9c-13-13.1-34.4-13.1-47.4 0zm-94 322.3l-53.4-53.4c-12.5-12.5-33-12.5-45.5 0L184.7 663.2c-12.5 12.5-12.5 33 0 45.5l106.7 106.7c12.5 12.5 33 12.5 45.5 0L458 694.1c-25.6-52.9-21-116.8 13.9-165.9z"/>
+  </g>
 </svg>

--- a/collectors/ci-otel/cmd-end.sh
+++ b/collectors/ci-otel/cmd-end.sh
@@ -40,9 +40,11 @@ fi
 cmd_hash=$(echo -n "${LUNAR_CI_JOB_ID:-}-${LUNAR_CI_STEP_INDEX}-${LUNAR_CI_COMMAND_PID}-${LUNAR_CI_COMMAND_PPID:-}-${LUNAR_CI_COMMAND:-}" | sha256sum | awk '{print $1}')
 
 cmd_file="/tmp/lunar-otel-cmd-${cmd_hash}"
-echo "cmd_file: $cmd_file"
-#echo "cmd_file contents: $(cat $cmd_file)"
-echo "/tmp dir content:  $(ls -la /tmp)"
+
+# Debug logging (gated to avoid leaking secrets in CI logs)
+if [ "${LUNAR_VAR_debug:-false}" = "true" ]; then
+  echo "OTEL DEBUG: cmd_file=$cmd_file" >&2
+fi
 
 # Make sure the file exists and has content
 if ! head -n 1 "$cmd_file" >/dev/null 2>&1; then

--- a/collectors/ci-otel/cmd-end.sh
+++ b/collectors/ci-otel/cmd-end.sh
@@ -3,8 +3,8 @@ set -e
 
 source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
 
-trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
-root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+trace_id=$(cat /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
 
 if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
   # Use a temporary key for skipped events without trace_id
@@ -49,7 +49,7 @@ if ! head -n 1 "$cmd_file" >/dev/null 2>&1; then
   echo "OTEL: No start time found for command hash ${cmd_hash}, skipping"
   debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.status" "skipped_no_start" \
     ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
-    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.command" "${LUNAR_CI_COMMAND:-}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.command" "${LUNAR_CI_COMMAND:-}"
   exit 0
 fi
 

--- a/collectors/ci-otel/cmd-end.sh
+++ b/collectors/ci-otel/cmd-end.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
+
+trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+
+if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
+  # Use a temporary key for skipped events without trace_id
+  skip_key="skipped_$(date +%s%N | head -c 13)_pid_${LUNAR_CI_COMMAND_PID:-unknown}"
+  debug_collect ".ci.debug.cmd_end.$skip_key.status" "skipped_no_context"
+  exit 0
+fi
+
+# Use command PID to look up span info
+if [ -z "${LUNAR_CI_COMMAND_PID:-}" ]; then
+  echo "OTEL: No command PID found, skipping command span"
+  skip_key="skipped_$(date +%s%N | head -c 13)_no_pid"
+  debug_collect ".ci.debug.cmd_end.$skip_key.status" "skipped_no_pid"
+  exit 0
+fi
+
+# Only trace commands that belong to a step - filter out internal CI runner processes
+# Commands without step_index are internal CI runner processes (like git, sed, basename, etc.)
+# that don't map to user-defined CI workflow steps and should not be traced
+if [ -z "${LUNAR_CI_STEP_INDEX:-}" ]; then
+  echo "OTEL: Command does not belong to a step (no step_index), skipping internal CI runner process" >&2
+  
+  # Debug logging under internal_processes category
+  debug_collect ".ci.traces.$trace_id.debug.internal_processes.${LUNAR_CI_COMMAND_PID}.cmd_end.status" "skipped_no_step_index" \
+    ".ci.traces.$trace_id.debug.internal_processes.${LUNAR_CI_COMMAND_PID}.cmd_end.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
+    ".ci.traces.$trace_id.debug.internal_processes.${LUNAR_CI_COMMAND_PID}.cmd_end.cmd" "${LUNAR_CI_COMMAND:-}"
+  
+  exit 0
+fi
+
+# Generate command hash to look up the start time file
+# Include job_id, step_id, PID, PPID, and command in hash to make each command instance unique
+cmd_hash=$(echo -n "${LUNAR_CI_JOB_ID:-}-${LUNAR_CI_STEP_INDEX}-${LUNAR_CI_COMMAND_PID}-${LUNAR_CI_COMMAND_PPID:-}-${LUNAR_CI_COMMAND:-}" | sha256sum | awk '{print $1}')
+
+cmd_file="/tmp/lunar-otel-cmd-${cmd_hash}"
+echo "cmd_file: $cmd_file"
+#echo "cmd_file contents: $(cat $cmd_file)"
+echo "/tmp dir content:  $(ls -la /tmp)"
+
+# Make sure the file exists and has content
+if ! head -n 1 "$cmd_file" >/dev/null 2>&1; then
+  echo "OTEL: No start time found for command hash ${cmd_hash}, skipping"
+  debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.status" "skipped_no_start" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.command" "${LUNAR_CI_COMMAND:-}" \
+  exit 0
+fi
+
+start_time=$(sed -n '1p' "$cmd_file")
+span_id=$(sed -n '2p' "$cmd_file")
+parent_span_id=$(sed -n '3p' "$cmd_file")
+# Get the command from the stored file
+stored_cmd=$(sed -n '4p' "$cmd_file")
+cmd="$stored_cmd"
+end_time=$(nanoseconds)
+
+# Ensure parent_span_id is never empty (commands should never be root spans)
+# Commands must be children of steps or other commands, never the root job span
+# If parent_span_id is empty, skip sending this command span
+if [ -z "$parent_span_id" ]; then
+  echo "OTEL: Warning - command parent span ID is empty, skipping command span" >&2
+  debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.status" "skipped_empty_parent" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.span_id" "$span_id" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.cmd" "${LUNAR_CI_COMMAND:-}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_end.step_index" "${LUNAR_CI_STEP_INDEX}"
+  exit 0
+fi
+
+# Use the full command as span name
+# cmd is a JSON array like ["/usr/bin/git","version"]
+span_name="$cmd"
+
+# Calculate duration
+duration_ns=$((end_time - start_time))
+duration_ms=$((duration_ns / 1000000))
+
+# Structured collection for debugging: Update command object with completion info (we know step_index exists because we filtered above)
+debug_collect ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.end_time" "$end_time" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.duration_ns" "$duration_ns" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.duration_ms" "$duration_ms" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.span_name" "$span_name" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.completed" "true"
+
+# Build attributes before sending (to catch errors early)
+cmd_attrs=$(build_command_attributes "$cmd" "$cmd_hash") || {
+  echo "OTEL: ERROR - Failed to build command attributes" >&2
+  exit 1
+}
+
+send_span \
+  "$trace_id" \
+  "$span_id" \
+  "$parent_span_id" \
+  "$span_name" \
+  "$start_time" \
+  "$end_time" \
+  "$cmd_attrs" || {
+  echo "OTEL: ERROR - Failed to send command span" >&2
+  exit 1
+}
+
+# Cleanup
+rm -f "$cmd_file"
+pid_map_file="/tmp/lunar-otel-pid-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX:-unknown}-${LUNAR_CI_COMMAND_PID}"
+rm -f "$pid_map_file"
+

--- a/collectors/ci-otel/cmd-start.sh
+++ b/collectors/ci-otel/cmd-start.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -e
+
+source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
+
+trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+
+if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
+  echo "OTEL: No trace context found, skipping command span (trace_id='$trace_id', root_span_id='$root_span_id')" >&2
+  # Use a temporary key for skipped events without trace_id
+  skip_key="skipped_$(date +%s%N | head -c 13)_pid_${LUNAR_CI_COMMAND_PID:-unknown}"
+  debug_collect ".ci.debug.cmd_start.$skip_key.status" "skipped_no_context"
+  exit 0
+fi
+
+# Debug: Log trace context for troubleshooting
+echo "OTEL: cmd-start: trace_id=$trace_id, root_span_id=$root_span_id, step_index=${LUNAR_CI_STEP_INDEX:-}, cmd_pid=${LUNAR_CI_COMMAND_PID:-}" >&2
+
+# Use command PID for span ID (convert to hex)
+if [ -z "${LUNAR_CI_COMMAND_PID:-}" ]; then
+  echo "OTEL: No command PID found, skipping command span"
+  skip_key="skipped_$(date +%s%N | head -c 13)_no_pid"
+  debug_collect ".ci.debug.cmd_start.$skip_key.status" "skipped_no_pid"
+  exit 0
+fi
+
+# Only trace commands that belong to a step - filter out internal CI runner processes
+# Commands without step_index are internal CI runner processes (like git, sed, basename, etc.)
+# that don't map to user-defined CI workflow steps and should not be traced
+if [ -z "${LUNAR_CI_STEP_INDEX:-}" ]; then
+  echo "OTEL: Command does not belong to a step (no step_index), skipping internal CI runner process: ${LUNAR_CI_COMMAND:-}" >&2
+  
+  # Collect internal processes for debugging purposes
+  # Include job_id, step_id, PID, PPID, and command in hash to make each command instance unique
+  cmd_hash=$(echo -n "${LUNAR_CI_JOB_ID:-}-${LUNAR_CI_STEP_INDEX:-}-${LUNAR_CI_COMMAND_PID}-${LUNAR_CI_COMMAND_PPID:-}-${LUNAR_CI_COMMAND:-}" | sha256sum | awk '{print $1}')
+  
+  debug_collect ".ci.traces.$trace_id.internal_processes.$cmd_hash.command" "${LUNAR_CI_COMMAND:-}" \
+    ".ci.traces.$trace_id.internal_processes.$cmd_hash.cmd_hash" "$cmd_hash" \
+    ".ci.traces.$trace_id.internal_processes.$cmd_hash.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
+    ".ci.traces.$trace_id.internal_processes.$cmd_hash.cmd_ppid" "${LUNAR_CI_COMMAND_PPID:-}" \
+    ".ci.traces.$trace_id.internal_processes.$cmd_hash.status" "skipped_no_step_index"
+  
+  exit 0
+fi
+
+span_id=$(generate_command_span_id)
+parent_span_id=$(get_command_parent_span_id)
+start_time=$(nanoseconds)
+
+# Ensure parent_span_id is never empty (commands should never be root spans)
+# Commands must be children of steps or other commands, never the root job span
+# If we can't determine a valid parent (step or command), skip sending this command span
+if [ -z "$parent_span_id" ]; then
+  echo "OTEL: Warning - cannot determine step or command parent for command, skipping" >&2
+  debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.${LUNAR_CI_COMMAND_PID}.cmd_start.status" "skipped_no_parent" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.${LUNAR_CI_COMMAND_PID}.cmd_start.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.${LUNAR_CI_COMMAND_PID}.cmd_start.step_index" "${LUNAR_CI_STEP_INDEX}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.${LUNAR_CI_COMMAND_PID}.cmd_start.cmd_ppid" "${LUNAR_CI_COMMAND_PPID:-}" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.commands.${LUNAR_CI_COMMAND_PID}.cmd_start.cmd" "${LUNAR_CI_COMMAND:-}"
+
+  exit 0
+fi
+
+# Generate command hash for structured collection and file naming
+# Include job_id, step_id, PID, PPID, and command in hash to make each command instance unique
+cmd_hash=$(echo -n "${LUNAR_CI_JOB_ID:-}-${LUNAR_CI_STEP_INDEX}-${LUNAR_CI_COMMAND_PID}-${LUNAR_CI_COMMAND_PPID:-}-${LUNAR_CI_COMMAND:-}" | sha256sum | awk '{print $1}')
+
+# Store span info keyed by cmd_hash so we can look it up later
+# Format: start_time,span_id,parent_span_id,command
+cmd_file="/tmp/lunar-otel-cmd-${cmd_hash}"
+echo "cmd_file: $cmd_file"
+echo "$start_time" > "$cmd_file"
+echo "$span_id" >> "$cmd_file"
+echo "$parent_span_id" >> "$cmd_file"
+echo "$LUNAR_CI_COMMAND" >> "$cmd_file"
+echo "cmd_file contents: $(cat $cmd_file)"
+echo "/tmp dir content:  $(ls -la /tmp)"
+
+# Also store PID -> span_id mapping for parent lookups
+# Use job_id-step_id-pid to ensure uniqueness across different jobs/steps (PIDs can be reused)
+pid_map_file="/tmp/lunar-otel-pid-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX:-unknown}-${LUNAR_CI_COMMAND_PID}"
+echo "$span_id" > "$pid_map_file"
+
+# Structured collection for debugging: Create command object (we know step_index exists because we filtered above)
+debug_collect ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.command" "${LUNAR_CI_COMMAND:-}" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_hash" "$cmd_hash" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_pid" "${LUNAR_CI_COMMAND_PID}" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.cmd_ppid" "${LUNAR_CI_COMMAND_PPID:-}" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.span_id" "$span_id" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.parent_span_id" "$parent_span_id" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.start_time" "$start_time" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.commands.$cmd_hash.status" "started"

--- a/collectors/ci-otel/cmd-start.sh
+++ b/collectors/ci-otel/cmd-start.sh
@@ -3,8 +3,8 @@ set -e
 
 source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
 
-trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
-root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+trace_id=$(cat /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
 
 if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
   echo "OTEL: No trace context found, skipping command span (trace_id='$trace_id', root_span_id='$root_span_id')" >&2

--- a/collectors/ci-otel/cmd-start.sh
+++ b/collectors/ci-otel/cmd-start.sh
@@ -69,13 +69,15 @@ cmd_hash=$(echo -n "${LUNAR_CI_JOB_ID:-}-${LUNAR_CI_STEP_INDEX}-${LUNAR_CI_COMMA
 # Store span info keyed by cmd_hash so we can look it up later
 # Format: start_time,span_id,parent_span_id,command
 cmd_file="/tmp/lunar-otel-cmd-${cmd_hash}"
-echo "cmd_file: $cmd_file"
 echo "$start_time" > "$cmd_file"
 echo "$span_id" >> "$cmd_file"
 echo "$parent_span_id" >> "$cmd_file"
 echo "$LUNAR_CI_COMMAND" >> "$cmd_file"
-echo "cmd_file contents: $(cat $cmd_file)"
-echo "/tmp dir content:  $(ls -la /tmp)"
+
+# Debug logging (gated to avoid leaking secrets in CI logs)
+if [ "${LUNAR_VAR_debug:-false}" = "true" ]; then
+  echo "OTEL DEBUG: cmd_file=$cmd_file" >&2
+fi
 
 # Also store PID -> span_id mapping for parent lookups
 # Use job_id-step_id-pid to ensure uniqueness across different jobs/steps (PIDs can be reused)

--- a/collectors/ci-otel/install.sh
+++ b/collectors/ci-otel/install.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 set -e
 
-# Install xxd if not available
+# Verify required dependencies (must be pre-installed in CI environment)
+for dep in curl jq; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: Missing required dependency '$dep'. Please install it in your CI runner." >&2
+    exit 1
+  fi
+done
+
+# xxd is optional (only used as fallback for span ID generation in debug scenarios)
+# Try to install it if not available, but don't fail if we can't
 if ! command -v xxd >/dev/null 2>&1; then
-  echo "Installing xxd..."
+  echo "Installing xxd (optional, for span ID generation fallback)..."
   if command -v apk >/dev/null 2>&1; then
-    apk add --no-cache xxd
+    apk add --no-cache xxd 2>/dev/null || true
   elif command -v apt-get >/dev/null 2>&1; then
-    apt-get update -qq && apt-get install -y -qq xxd || apt-get install -y -qq vim-common
+    apt-get update -qq && apt-get install -y -qq xxd 2>/dev/null || apt-get install -y -qq vim-common 2>/dev/null || true
   elif command -v yum >/dev/null 2>&1; then
-    yum install -y vim-common
-  else
-    echo "Warning: No supported package manager found (apk/apt-get/yum). xxd may not be available." >&2
+    yum install -y vim-common 2>/dev/null || true
   fi
 fi
 

--- a/collectors/ci-otel/install.sh
+++ b/collectors/ci-otel/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Install xxd if not available (part of vim-common or xxd package)
+if ! command -v xxd >/dev/null 2>&1; then
+  echo "Installing xxd..."
+  apt-get update -qq && apt-get install -y -qq xxd || apt-get install -y -qq vim-common
+fi
+
+echo "ci-otel collector dependencies verified"
+

--- a/collectors/ci-otel/install.sh
+++ b/collectors/ci-otel/install.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 set -e
 
-# Install xxd if not available (part of vim-common or xxd package)
+# Install xxd if not available
 if ! command -v xxd >/dev/null 2>&1; then
   echo "Installing xxd..."
-  apt-get update -qq && apt-get install -y -qq xxd || apt-get install -y -qq vim-common
+  if command -v apk >/dev/null 2>&1; then
+    apk add --no-cache xxd
+  elif command -v apt-get >/dev/null 2>&1; then
+    apt-get update -qq && apt-get install -y -qq xxd || apt-get install -y -qq vim-common
+  elif command -v yum >/dev/null 2>&1; then
+    yum install -y vim-common
+  else
+    echo "Warning: No supported package manager found (apk/apt-get/yum). xxd may not be available." >&2
+  fi
 fi
 
 echo "ci-otel collector dependencies verified"

--- a/collectors/ci-otel/job-end.sh
+++ b/collectors/ci-otel/job-end.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
+
+trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+start_time=$(cat /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "0")
+end_time=$(nanoseconds)
+
+if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
+  echo "OTEL: No trace context found, skipping job end span"
+  # Use a temporary key for skipped events without trace_id
+  skip_key="skipped_$(date +%s%N | head -c 13)"
+  debug_collect ".ci.debug.job_end.$skip_key.status" "skipped_no_context" \
+    ".ci.debug.job_end.$skip_key.trace_id" "$trace_id" \
+    ".ci.debug.job_end.$skip_key.root_span_id" "$root_span_id"
+  exit 0
+fi
+
+# Debug: Log trace context
+echo "OTEL: job-end: trace_id=$trace_id, root_span_id=$root_span_id, job_id=${LUNAR_CI_JOB_ID:-}" >&2
+
+# Build and send the final root span
+span_name="$(build_job_span_name)"
+
+# Ensure span name is never empty (fallback to job ID if component info is missing)
+if [ -z "$span_name" ]; then
+  span_name="CI Job ${LUNAR_CI_JOB_ID:-unknown}"
+fi
+
+# Calculate duration
+duration_ns=$((end_time - start_time))
+duration_ms=$((duration_ns / 1000000))
+
+# Structured collection for debugging: Update root trace object with completion info
+debug_collect ".ci.traces.$trace_id.end_time" "$end_time" \
+  ".ci.traces.$trace_id.duration_ns" "$duration_ns" \
+  ".ci.traces.$trace_id.duration_ms" "$duration_ms" \
+  ".ci.traces.$trace_id.span_name" "$span_name" \
+  ".ci.traces.$trace_id.job_name" "${LUNAR_CI_JOB_NAME:-unknown}" \
+  ".ci.traces.$trace_id.completed" "true"
+
+# Build attributes before sending (to catch errors early)
+job_attrs=$(build_job_attributes) || {
+  echo "OTEL: ERROR - Failed to build job attributes" >&2
+  debug_collect ".ci.traces.$trace_id.debug.job_end.errors.build_attributes_failed" "true"
+  exit 1
+}
+
+send_span \
+  "$trace_id" \
+  "$root_span_id" \
+  "" \
+  "$span_name" \
+  "$start_time" \
+  "$end_time" \
+  "$job_attrs" || {
+  echo "OTEL: ERROR - Failed to send job span" >&2
+  debug_collect ".ci.traces.$trace_id.debug.job_end.errors.send_span_failed" "true"
+  exit 1
+}
+
+# Cleanup
+rm -f /tmp/lunar-otel-trace-id /tmp/lunar-otel-root-span-id /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown}

--- a/collectors/ci-otel/job-end.sh
+++ b/collectors/ci-otel/job-end.sh
@@ -3,13 +3,13 @@ set -e
 
 source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
 
-trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
-root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
-start_time=$(cat /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "0")
+trace_id=$(cat /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
+start_time=$(cat /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
 end_time=$(nanoseconds)
 
-if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
-  echo "OTEL: No trace context found, skipping job end span"
+if [ -z "$trace_id" ] || [ -z "$root_span_id" ] || [ -z "$start_time" ]; then
+  echo "OTEL: No trace context or start time found, skipping job end span"
   # Use a temporary key for skipped events without trace_id
   skip_key="skipped_$(date +%s%N | head -c 13)"
   debug_collect ".ci.debug.job_end.$skip_key.status" "skipped_no_context" \
@@ -62,4 +62,4 @@ send_span \
 }
 
 # Cleanup
-rm -f /tmp/lunar-otel-trace-id /tmp/lunar-otel-root-span-id /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown}
+rm -f /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown}

--- a/collectors/ci-otel/job-start.sh
+++ b/collectors/ci-otel/job-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
+
+# Generate trace ID from component + job ID
+trace_id=$(generate_trace_id)
+root_span_id=$(generate_job_span_id)
+start_time=$(nanoseconds)
+
+# Store trace context for child spans
+echo "$trace_id" > /tmp/lunar-otel-trace-id
+echo "$root_span_id" > /tmp/lunar-otel-root-span-id
+echo "$start_time" > /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown}
+
+# Structured collection for debugging: Create root trace object
+debug_collect ".ci.traces.$trace_id.trace_id" "$trace_id" \
+  ".ci.traces.$trace_id.root_span_id" "$root_span_id" \
+  ".ci.traces.$trace_id.job_id" "${LUNAR_CI_JOB_ID:-}" \
+  ".ci.traces.$trace_id.job_name" "${LUNAR_CI_JOB_NAME:-unknown}" \
+  ".ci.traces.$trace_id.component_id" "${LUNAR_COMPONENT_ID:-}" \
+  ".ci.traces.$trace_id.git_sha" "${LUNAR_COMPONENT_GIT_SHA:-}" \
+  ".ci.traces.$trace_id.pr" "${LUNAR_COMPONENT_PR:-}" \
+  ".ci.traces.$trace_id.start_time" "$start_time" \
+  ".ci.traces.$trace_id.status" "started"
+
+echo "OTEL: Started trace $trace_id for job"
+

--- a/collectors/ci-otel/job-start.sh
+++ b/collectors/ci-otel/job-start.sh
@@ -8,9 +8,9 @@ trace_id=$(generate_trace_id)
 root_span_id=$(generate_job_span_id)
 start_time=$(nanoseconds)
 
-# Store trace context for child spans
-echo "$trace_id" > /tmp/lunar-otel-trace-id
-echo "$root_span_id" > /tmp/lunar-otel-root-span-id
+# Store trace context for child spans (scoped by job ID to avoid cross-job contamination)
+echo "$trace_id" > /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown}
+echo "$root_span_id" > /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown}
 echo "$start_time" > /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown}
 
 # Structured collection for debugging: Create root trace object

--- a/collectors/ci-otel/lunar-collector.yml
+++ b/collectors/ci-otel/lunar-collector.yml
@@ -13,7 +13,7 @@ landing_page:
     Instruments CI pipelines with OpenTelemetry distributed tracing.
     Captures job, step, and command-level spans for detailed CI observability.
     Sends traces to any OTLP-compatible backend (Tempo, Jaeger, etc.).
-  category: "devex-build-and-ci"
+  category: "ci-cd"
   icon: "assets/ci-otel.svg"
   status: "stable"
   related: []

--- a/collectors/ci-otel/lunar-collector.yml
+++ b/collectors/ci-otel/lunar-collector.yml
@@ -1,0 +1,104 @@
+version: 0
+
+name: ci-otel
+description: Emit OpenTelemetry traces for CI pipeline runs
+author: support@earthly.dev
+
+default_image: earthly/lunar-scripts:1.0.0
+default_image_ci_collectors: native
+
+landing_page:
+  display_name: "CI OpenTelemetry Collector"
+  long_description: |
+    Instruments CI pipelines with OpenTelemetry distributed tracing.
+    Captures job, step, and command-level spans for detailed CI observability.
+    Sends traces to any OTLP-compatible backend (Tempo, Jaeger, etc.).
+  category: "devex-build-and-ci"
+  icon: "assets/ci-otel.svg"
+  status: "stable"
+  related: []
+
+inputs:
+  otel_endpoint:
+    description: The OTLP HTTP endpoint for sending traces (e.g., http://tempo:4318)
+    default: "http://tempo:4318"
+  debug:
+    description: Enable debug mode to collect detailed debugging information in the Component JSON
+    default: "false"
+
+collectors:
+  - name: job-start
+    description: |
+      Starts the root span for the CI job. Generates trace ID from component
+      and job ID, stores context in temp files for child spans.
+    mainBash: job-start.sh
+    hook:
+      type: ci-before-job
+      pattern: .*
+    keywords: ["opentelemetry", "tracing", "ci job", "observability"]
+
+  - name: job-end
+    description: |
+      Ends the root span for the CI job. Reads start time from temp file,
+      calculates duration, and sends the complete span to the OTLP endpoint.
+    mainBash: job-end.sh
+    hook:
+      type: ci-after-job
+      pattern: .*
+    keywords: ["opentelemetry", "tracing", "ci job", "span completion"]
+
+  - name: step-start
+    description: |
+      Starts a span for each CI step. Creates child span under the job root
+      span, stores step context for command spans.
+    mainBash: step-start.sh
+    hook:
+      type: ci-before-step
+      pattern: .*
+    keywords: ["opentelemetry", "tracing", "ci step", "observability"]
+
+  - name: step-end
+    description: |
+      Ends the span for each CI step. Calculates step duration and sends
+      the complete span to the OTLP endpoint.
+    mainBash: step-end.sh
+    hook:
+      type: ci-after-step
+      pattern: .*
+    keywords: ["opentelemetry", "tracing", "ci step", "span completion"]
+
+  - name: cmd-start
+    description: |
+      Starts a span for each CI command. Creates child span under the current
+      step, captures command details and PID for correlation.
+    mainBash: cmd-start.sh
+    hook:
+      type: ci-before-command
+      pattern: .*
+    keywords: ["opentelemetry", "tracing", "ci command", "process tracing"]
+
+  - name: cmd-end
+    description: |
+      Ends the span for each CI command. Captures exit code, calculates
+      duration, and sends the complete span with command metadata.
+    mainBash: cmd-end.sh
+    hook:
+      type: ci-after-command
+      pattern: .*
+    keywords: ["opentelemetry", "tracing", "ci command", "span completion"]
+
+example_component_json: |
+  {
+    "ci": {
+      "traces": {
+        "abc123def456...": {
+          "trace_id": "abc123def456...",
+          "root_span_id": "1234567890abcdef",
+          "job_id": "12345",
+          "job_name": "build",
+          "component_id": "github.com/acme/myproject",
+          "status": "completed"
+        }
+      }
+    }
+  }

--- a/collectors/ci-otel/otel-helpers.sh
+++ b/collectors/ci-otel/otel-helpers.sh
@@ -1,0 +1,409 @@
+#!/bin/bash
+# OTEL helper functions for CI tracing
+
+# Endpoint from collector input (LUNAR_VAR_otel_endpoint) or fallback
+# Send directly to Tempo (port 4318 is OTLP HTTP)
+OTEL_ENDPOINT="${LUNAR_VAR_otel_endpoint:-${LUNAR_VAR_OTEL_ENDPOINT:-http://tempo:4318}}"
+
+# Helper function to conditionally run debug collection
+# Usage: debug_collect "key1" "value1" "key2" "value2" ...
+debug_collect() {
+  local debug_val="${LUNAR_VAR_debug:-${LUNAR_VAR_DEBUG:-false}}"
+  if [ "$debug_val" = "true" ]; then
+    lunar collect "$@" 2>/dev/null || true
+  fi
+}
+
+# Convert a number to a 16-char hex span ID (pads with zeros)
+pid_to_span_id() {
+  local pid="$1"
+  # Convert to hex, pad to 16 chars with zeros
+  printf "%016x" "$pid" 2>/dev/null || echo -n "$pid" | xxd -p | head -c 16 | xargs printf "%016s" | tr ' ' '0'
+}
+
+# Convert a string to a 32-char hex trace ID
+string_to_trace_id() {
+  local input="$1"
+  echo -n "$input" | sha256sum | cut -c1-32
+}
+
+# Generate a 32-char hex trace ID from component + CI job ID + run attempt
+generate_trace_id() {
+  local seed=""
+  
+  # Use component ID as base
+  seed="${LUNAR_COMPONENT_ID:-unknown}"
+  
+  # Use CI job ID if available, otherwise fallback to timestamp
+  if [ -n "${LUNAR_CI_JOB_ID:-}" ]; then
+    seed="${seed}-${LUNAR_CI_JOB_ID}"
+    # Include run attempt to distinguish retries (only if > 0)
+    if [ -n "${LUNAR_CI_PIPELINE_RUN_ATTEMPT:-}" ] && [ "${LUNAR_CI_PIPELINE_RUN_ATTEMPT}" -gt 0 ] 2>/dev/null; then
+      seed="${seed}-${LUNAR_CI_PIPELINE_RUN_ATTEMPT}"
+    fi
+  else
+    seed="${seed}-$(date +%s%N)"
+  fi
+  
+  # Hash to get consistent 32-char hex
+  string_to_trace_id "$seed"
+}
+
+# Generate a 16-char hex span ID from CI job ID + run attempt
+generate_job_span_id() {
+  if [ -n "${LUNAR_CI_JOB_ID:-}" ]; then
+    # Include run attempt to distinguish retries (only if > 0)
+    local job_id_with_attempt="${LUNAR_CI_JOB_ID}"
+    if [ -n "${LUNAR_CI_PIPELINE_RUN_ATTEMPT:-}" ] && [ "${LUNAR_CI_PIPELINE_RUN_ATTEMPT}" -gt 0 ] 2>/dev/null; then
+      job_id_with_attempt="${job_id_with_attempt}-${LUNAR_CI_PIPELINE_RUN_ATTEMPT}"
+    fi
+    # Use job ID + attempt (hash to get consistent hex)
+    string_to_trace_id "$job_id_with_attempt" | cut -c1-16
+  else
+    # Fallback: generate random span ID
+    head -c 8 /dev/urandom | xxd -p
+  fi
+}
+
+# Generate a 16-char hex span ID from CI step index
+# Uses LUNAR_CI_JOB_ID + "-step-" + LUNAR_CI_STEP_INDEX for global uniqueness
+# The "step-" prefix ensures it doesn't collide with job span ID (which uses job_id + "-" + run_attempt)
+generate_step_span_id() {
+  local step_id="${LUNAR_CI_JOB_ID}-step-${LUNAR_CI_STEP_INDEX}"
+  string_to_trace_id "$step_id" | cut -c1-16
+}
+
+# Generate a 16-char hex span ID from command PID
+generate_command_span_id() {
+  if [ -n "${LUNAR_CI_COMMAND_PID:-}" ]; then
+    pid_to_span_id "$LUNAR_CI_COMMAND_PID"
+  else
+    # Fallback: generate random span ID
+    head -c 8 /dev/urandom | xxd -p
+  fi
+}
+
+# Get parent span ID for a command
+# Returns step span ID if PPID is not set, otherwise returns span ID for PPID
+# Commands should NEVER use root_span_id as parent - they must be children of steps or other commands
+# This ensures commands can never become root spans even if the job span isn't sent
+get_command_parent_span_id() {
+  if [ -n "${LUNAR_CI_COMMAND_PPID:-}" ]; then
+    # Parent is another command - look up its span ID from stored mapping
+    # Use job_id-step_id-ppid to ensure uniqueness (PIDs can be reused across different jobs/steps)
+    # If not found, convert PPID directly to span ID (parent command may not have been traced)
+    local parent_span_id
+    pid_map_file="/tmp/lunar-otel-pid-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX:-unknown}-${LUNAR_CI_COMMAND_PPID}"
+    parent_span_id=$(cat "$pid_map_file" 2>/dev/null)
+    if [ -n "$parent_span_id" ]; then
+      echo "$parent_span_id"
+    else
+      # Fallback: convert PPID to span ID directly
+      pid_to_span_id "$LUNAR_CI_COMMAND_PPID"
+    fi
+  else
+    # Parent is the step (step hooks guarantee LUNAR_CI_STEP_INDEX is set)
+    # If step span ID generation fails, return empty (command will be skipped)
+    # We do NOT fall back to root_span_id to prevent commands from becoming root spans
+    generate_step_span_id 2>/dev/null || echo ""
+  fi
+}
+
+# Generate a 16-char hex span ID (fallback for when no specific ID is available)
+generate_span_id() {
+  # Use /dev/urandom for uniqueness
+  head -c 8 /dev/urandom | xxd -p
+}
+
+# Get current time in nanoseconds since epoch
+nanoseconds() {
+  if date +%s%N | grep -q 'N'; then
+    # macOS doesn't support %N, use seconds * 1e9
+    echo "$(($(date +%s) * 1000000000))"
+  else
+    date +%s%N
+  fi
+}
+
+# Build the base job/root span name: Use job name, fallback to component_id git_sha #PR
+build_job_span_name() {
+  # Prefer job name if available
+  if [ -n "${LUNAR_CI_JOB_NAME:-}" ]; then
+    echo "$LUNAR_CI_JOB_NAME"
+    return
+  fi
+
+  # Fallback to component_id git_sha #PR format
+  # Use short SHA (first 7 chars)
+  local short_sha
+  short_sha=$(echo "${LUNAR_COMPONENT_GIT_SHA:-}" | cut -c1-7)
+
+  local name="$LUNAR_COMPONENT_ID"
+  if [ -n "$short_sha" ]; then
+    name="$name $short_sha"
+  fi
+  if [ -n "$LUNAR_COMPONENT_PR" ]; then
+    name="$name #$LUNAR_COMPONENT_PR"
+  fi
+
+  echo "$name"
+}
+
+# Build attributes JSON for the job/root span
+build_job_attributes() {
+  local attrs="[]"
+  
+  # Component info from Lunar
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_ID:-}" '. + [{"key": "lunar.component_id", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_PR:-}" '. + [{"key": "lunar.pr", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_GIT_SHA:-}" '. + [{"key": "lunar.git_sha", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_DOMAIN:-}" '. + [{"key": "lunar.domain", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_OWNER:-}" '. + [{"key": "lunar.owner", "value": {"stringValue": $v}}]')
+
+  # CI vendor (hardcoded for now)
+  # TODO: Replace with LUNAR_CI_VENDOR when available
+  attrs=$(echo "$attrs" | jq --arg v "github-actions" '. + [{"key": "ci.vendor", "value": {"stringValue": $v}}]')
+  
+  # Span type identifier
+  attrs=$(echo "$attrs" | jq --arg v "job" '. + [{"key": "ci.span_type", "value": {"stringValue": $v}}]')
+  
+  # CI job metadata
+  if [ -n "${LUNAR_CI_JOB_ID:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_JOB_ID}" '. + [{"key": "ci.job_id", "value": {"stringValue": $v}}]')
+  fi
+  if [ -n "${LUNAR_CI_JOB_NAME:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_JOB_NAME}" '. + [{"key": "ci.job_name", "value": {"stringValue": $v}}]')
+  fi
+  if [ -n "${LUNAR_CI_PIPELINE_RUN_ID:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_PIPELINE_RUN_ID}" '. + [{"key": "ci.pipeline_run_id", "value": {"stringValue": $v}}]')
+  fi
+  if [ -n "${LUNAR_CI_PIPELINE_RUN_ATTEMPT:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_PIPELINE_RUN_ATTEMPT}" '. + [{"key": "ci.pipeline_run_attempt", "value": {"stringValue": $v}}]')
+  fi
+  if [ -n "${LUNAR_CI_PIPELINE_NAME:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_PIPELINE_NAME}" '. + [{"key": "ci.pipeline_name", "value": {"stringValue": $v}}]')
+  fi
+  if [ -n "${LUNAR_CI_PIPELINE_DEFINITION_REF:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_PIPELINE_DEFINITION_REF}" '. + [{"key": "ci.pipeline_definition_ref", "value": {"stringValue": $v}}]')
+  fi
+  
+  echo "$attrs"
+}
+
+# Build attributes JSON for a step span
+build_step_attributes() {
+  local attrs="[]"
+  
+  # Component info from Lunar (match job span attributes)
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_ID:-}" '. + [{"key": "lunar.component_id", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_PR:-}" '. + [{"key": "lunar.pr", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_GIT_SHA:-}" '. + [{"key": "lunar.git_sha", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_DOMAIN:-}" '. + [{"key": "lunar.domain", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_OWNER:-}" '. + [{"key": "lunar.owner", "value": {"stringValue": $v}}]')
+  
+  # CI vendor (same as job spans)
+  attrs=$(echo "$attrs" | jq --arg v "github-actions" '. + [{"key": "ci.vendor", "value": {"stringValue": $v}}]')
+  
+  # Span type identifier
+  attrs=$(echo "$attrs" | jq --arg v "step" '. + [{"key": "ci.span_type", "value": {"stringValue": $v}}]')
+  
+  # CI job metadata
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_JOB_ID}" '. + [{"key": "ci.job_id", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_JOB_NAME}" '. + [{"key": "ci.job_name", "value": {"stringValue": $v}}]')
+  
+  # Step metadata
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_STEP_INDEX}" '. + [{"key": "ci.step_index", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_STEP_NAME}" '. + [{"key": "ci.step_name", "value": {"stringValue": $v}}]')
+  
+  echo "$attrs"
+}
+
+# Build attributes JSON for a command span
+build_command_attributes() {
+  local cmd="$1"
+  local cmd_hash="$2"
+  local attrs="[]"
+  
+  attrs=$(echo "$attrs" | jq --arg v "$cmd" '. + [{"key": "ci.command", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "$cmd_hash" '. + [{"key": "ci.command_hash", "value": {"stringValue": $v}}]')
+  
+  # Component info from Lunar (match job span attributes)
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_ID:-}" '. + [{"key": "lunar.component_id", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_PR:-}" '. + [{"key": "lunar.pr", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_GIT_SHA:-}" '. + [{"key": "lunar.git_sha", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_DOMAIN:-}" '. + [{"key": "lunar.domain", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_COMPONENT_OWNER:-}" '. + [{"key": "lunar.owner", "value": {"stringValue": $v}}]')
+  
+  # CI vendor (same as job/step spans)
+  attrs=$(echo "$attrs" | jq --arg v "github-actions" '. + [{"key": "ci.vendor", "value": {"stringValue": $v}}]')
+  
+  # Span type identifier
+  attrs=$(echo "$attrs" | jq --arg v "command" '. + [{"key": "ci.span_type", "value": {"stringValue": $v}}]')
+  
+  # Add PID information for debugging
+  if [ -n "${LUNAR_CI_COMMAND_PID:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_COMMAND_PID}" '. + [{"key": "ci.command_pid", "value": {"stringValue": $v}}]')
+  fi
+  if [ -n "${LUNAR_CI_COMMAND_PPID:-}" ]; then
+    attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_COMMAND_PPID}" '. + [{"key": "ci.command_ppid", "value": {"stringValue": $v}}]')
+  fi
+  
+  # Extract the command binary name (basename of first array element)
+  # cmd is a JSON array string like ["/usr/bin/git","version"]
+  local cmd_bin
+  if cmd_bin=$(echo "$cmd" | jq -r '.[0] // ""' 2>/dev/null); then
+    # Extract basename (everything after the last /)
+    cmd_bin="${cmd_bin##*/}"
+    if [ -n "$cmd_bin" ]; then
+      attrs=$(echo "$attrs" | jq --arg v "$cmd_bin" '. + [{"key": "ci.command_bin", "value": {"stringValue": $v}}]')
+    fi
+  fi
+  
+  # Always add job metadata (even if empty, for consistency)
+  # Commands should always have job context since they're part of a CI job
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_JOB_ID:-}" '. + [{"key": "ci.job_id", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_JOB_NAME:-}" '. + [{"key": "ci.job_name", "value": {"stringValue": $v}}]')
+  
+  # Always add step metadata (even if empty, for consistency)
+  # Note: Commands without step_index are filtered out in cmd-start.sh, so these should always be set
+  # But we include them always for consistency and to make filtering easier
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_STEP_INDEX:-}" '. + [{"key": "ci.step_index", "value": {"stringValue": $v}}]')
+  attrs=$(echo "$attrs" | jq --arg v "${LUNAR_CI_STEP_NAME:-}" '. + [{"key": "ci.step_name", "value": {"stringValue": $v}}]')
+  
+  echo "$attrs"
+}
+
+# Send a span to the OTEL collector via HTTP/JSON
+send_span() {
+  local trace_id="$1"
+  local span_id="$2"
+  local parent_span_id="$3"
+  local name="$4"
+  local start_time="$5"
+  local end_time="$6"
+  local attributes="$7"
+  
+  # Validate inputs
+  if [ -z "$trace_id" ] || [ -z "$span_id" ] || [ -z "$name" ]; then
+    echo "OTEL: ERROR - Missing required parameters: trace_id='$trace_id' span_id='$span_id' name='$name'" >&2
+    return 1
+  fi
+  
+  # Validate trace_id and span_id are hex strings (OpenTelemetry requirement)
+  if ! echo "$trace_id" | grep -qE '^[0-9a-f]{32}$'; then
+    echo "OTEL: ERROR - Invalid trace_id format (must be 32-char hex): '$trace_id'" >&2
+    return 1
+  fi
+  if ! echo "$span_id" | grep -qE '^[0-9a-f]{16}$'; then
+    echo "OTEL: ERROR - Invalid span_id format (must be 16-char hex): '$span_id'" >&2
+    return 1
+  fi
+  
+  # Validate parent_span_id format if provided (must be 16-char hex)
+  if [ -n "$parent_span_id" ] && ! echo "$parent_span_id" | grep -qE '^[0-9a-f]{16}$'; then
+    echo "OTEL: ERROR - Invalid parent_span_id format (must be 16-char hex): '$parent_span_id'" >&2
+    return 1
+  fi
+  
+  # Validate times are numeric
+  if ! echo "$start_time" | grep -qE '^[0-9]+$' || ! echo "$end_time" | grep -qE '^[0-9]+$'; then
+    echo "OTEL: ERROR - Invalid time format: start_time='$start_time' end_time='$end_time'" >&2
+    return 1
+  fi
+  
+  # Validate attributes is valid JSON array
+  if ! echo "$attributes" | jq -e '. | type == "array"' >/dev/null 2>&1; then
+    echo "OTEL: ERROR - Invalid attributes format (must be JSON array): '$attributes'" >&2
+    return 1
+  fi
+  
+  # Build the span JSON
+  local span_json
+  if ! span_json=$(jq -n \
+    --arg trace_id "$trace_id" \
+    --arg span_id "$span_id" \
+    --arg parent_span_id "$parent_span_id" \
+    --arg name "$name" \
+    --arg start_time "$start_time" \
+    --arg end_time "$end_time" \
+    --argjson attributes "$attributes" \
+    '{
+      traceId: $trace_id,
+      spanId: $span_id,
+      name: $name,
+      startTimeUnixNano: $start_time,
+      endTimeUnixNano: $end_time,
+      attributes: $attributes,
+      kind: 1,
+      status: {
+        code: 1
+      }
+    } + (if $parent_span_id != "" then {parentSpanId: $parent_span_id} else {} end)' 2>&1); then
+    echo "OTEL: ERROR - Failed to build span JSON: $span_json" >&2
+    return 1
+  fi
+  
+  # Wrap in OTLP structure
+  local otlp_payload
+
+  if ! otlp_payload=$(jq -n \
+    --argjson span "$span_json" \
+    --arg service_name "$LUNAR_COMPONENT_ID" \
+    '{
+      resourceSpans: [{
+        resource: {
+          attributes: [
+            {"key": "service.name", "value": {"stringValue": $service_name}}
+          ]
+        },
+        scopeSpans: [{
+          scope: {
+            name: "lunar-ci-otel",
+            version: "1.0.0"
+          },
+          spans: [$span]
+        }]
+      }]
+    }' 2>&1); then
+    echo "OTEL: ERROR - Failed to build OTLP payload: $otlp_payload" >&2
+    return 1
+  fi
+  
+  # Send to Tempo
+  echo "OTEL: Sending span '$name' (trace_id=$trace_id, span_id=$span_id, parent=$parent_span_id) to $OTEL_ENDPOINT" >&2
+  
+  # Debug: Validate the span JSON structure before sending
+  if ! echo "$span_json" | jq -e '.traceId and .spanId and .name and .startTimeUnixNano and .endTimeUnixNano' >/dev/null 2>&1; then
+    echo "OTEL: ERROR - Span JSON missing required fields: $(echo "$span_json" | jq -c '.')" >&2
+    return 1
+  fi
+  
+  # Debug: Log the span structure (first 500 chars to avoid huge logs)
+  local span_preview
+  span_preview=$(echo "$span_json" | jq -c '.' 2>/dev/null | head -c 500)
+  echo "OTEL: Span JSON preview: $span_preview..." >&2
+  
+  local response
+  local curl_exit_code=0
+  response=$(curl -s -w "\n%{http_code}" -X POST \
+    "${OTEL_ENDPOINT}/v1/traces" \
+    -H "Content-Type: application/json" \
+    -d "$otlp_payload" 2>&1) || curl_exit_code=$?
+  
+  if [ $curl_exit_code -ne 0 ]; then
+    echo "OTEL: ERROR - curl failed with exit code $curl_exit_code: $response" >&2
+    return 1
+  fi
+  
+  local http_code=$(echo "$response" | tail -n1)
+  local body=$(echo "$response" | sed '$d')
+  
+  if [ "$http_code" = "200" ] || [ "$http_code" = "202" ]; then
+    echo "OTEL: Successfully sent span '$name' (HTTP $http_code, trace_id=$trace_id)" >&2
+    return 0
+  else
+    echo "OTEL: Failed to send span '$name' to $OTEL_ENDPOINT (HTTP $http_code, trace_id=$trace_id): $body" >&2
+    return 1
+  fi
+}
+

--- a/collectors/ci-otel/step-end.sh
+++ b/collectors/ci-otel/step-end.sh
@@ -15,8 +15,8 @@ if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
   exit 0
 fi
 
-step_file="/tmp/lunar-otel-step-${LUNAR_CI_STEP_INDEX}"
-step_start_file="/tmp/lunar-otel-step-start-${LUNAR_CI_STEP_INDEX}"
+step_file="/tmp/lunar-otel-step-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX}"
+step_start_file="/tmp/lunar-otel-step-start-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX}"
 
 if [ ! -f "$step_file" ] || [ ! -f "$step_start_file" ]; then
   echo "OTEL: No step start found for step ${LUNAR_CI_STEP_INDEX}, skipping"

--- a/collectors/ci-otel/step-end.sh
+++ b/collectors/ci-otel/step-end.sh
@@ -3,8 +3,8 @@ set -e
 
 source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
 
-trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
-root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+trace_id=$(cat /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
 
 if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
   echo "OTEL: No trace context found, skipping step span"

--- a/collectors/ci-otel/step-end.sh
+++ b/collectors/ci-otel/step-end.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
+
+trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
+root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+
+if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
+  echo "OTEL: No trace context found, skipping step span"
+  # Use a temporary key for skipped events without trace_id
+  skip_key="skipped_$(date +%s%N | head -c 13)_step_${LUNAR_CI_STEP_INDEX:-unknown}"
+  debug_collect ".ci.debug.step_end.$skip_key.status" "skipped_no_context" \
+    ".ci.debug.step_end.$skip_key.step_index" "${LUNAR_CI_STEP_INDEX:-}"
+  exit 0
+fi
+
+step_file="/tmp/lunar-otel-step-${LUNAR_CI_STEP_INDEX}"
+step_start_file="/tmp/lunar-otel-step-start-${LUNAR_CI_STEP_INDEX}"
+
+if [ ! -f "$step_file" ] || [ ! -f "$step_start_file" ]; then
+  echo "OTEL: No step start found for step ${LUNAR_CI_STEP_INDEX}, skipping"
+  # Still try to mark the step as failed/not completed if we have trace context
+  debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.step_end.status" "skipped_no_start" \
+    ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.step_end.step_index" "${LUNAR_CI_STEP_INDEX}"
+  exit 0
+fi
+
+step_span_id=$(cat "$step_file")
+start_time=$(cat "$step_start_file")
+end_time=$(nanoseconds)
+
+# Debug: Log trace context
+echo "OTEL: step-end: trace_id=$trace_id, root_span_id=$root_span_id, step_span_id=$step_span_id, step_index=${LUNAR_CI_STEP_INDEX:-}" >&2
+
+# Build step name with "Step" prefix, step index, then step name
+step_name="Step ${LUNAR_CI_STEP_INDEX}: ${LUNAR_CI_STEP_NAME}"
+
+# Calculate duration
+duration_ns=$((end_time - start_time))
+duration_ms=$((duration_ns / 1000000))
+
+# Structured collection for debugging: Update step object with completion info
+# Also update step_name in case it wasn't available at step-start but is available now
+debug_collect ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.end_time" "$end_time" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.duration_ns" "$duration_ns" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.duration_ms" "$duration_ms" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.span_name" "$step_name" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.step_name" "${LUNAR_CI_STEP_NAME:-unknown}" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.completed" "true"
+
+# Build attributes before sending (to catch errors early)
+step_attrs=$(build_step_attributes) || {
+  echo "OTEL: ERROR - Failed to build step attributes" >&2
+  debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.step_end.errors.build_attributes_failed" "true"
+  exit 1
+}
+
+# Send final step span
+send_span \
+  "$trace_id" \
+  "$step_span_id" \
+  "$root_span_id" \
+  "$step_name" \
+  "$start_time" \
+  "$end_time" \
+  "$step_attrs" || {
+  echo "OTEL: ERROR - Failed to send step span" >&2
+  debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.step_end.errors.send_span_failed" "true"
+  exit 1
+}
+
+# Cleanup
+rm -f "$step_file" "$step_start_file"
+
+echo "OTEL: Completed step span $step_span_id for step ${LUNAR_CI_STEP_INDEX}"
+

--- a/collectors/ci-otel/step-start.sh
+++ b/collectors/ci-otel/step-start.sh
@@ -12,8 +12,8 @@ retry_delay=0.1
 retry_count=0
 
 while [ -z "$trace_id" ] || [ -z "$root_span_id" ]; do
-  trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
-  root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+  trace_id=$(cat /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
+  root_span_id=$(cat /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
   
   if [ -n "$trace_id" ] && [ -n "$root_span_id" ]; then
     break

--- a/collectors/ci-otel/step-start.sh
+++ b/collectors/ci-otel/step-start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+source "${LUNAR_PLUGIN_ROOT}/otel-helpers.sh"
+
+# For step 1, job-start.sh runs during ci-before-step, so there might be a race condition
+# Retry reading trace context a few times if it's not available yet (especially for step 1)
+trace_id=""
+root_span_id=""
+max_retries=5
+retry_delay=0.1
+retry_count=0
+
+while [ -z "$trace_id" ] || [ -z "$root_span_id" ]; do
+  trace_id=$(cat /tmp/lunar-otel-trace-id 2>/dev/null || echo "")
+  root_span_id=$(cat /tmp/lunar-otel-root-span-id 2>/dev/null || echo "")
+  
+  if [ -n "$trace_id" ] && [ -n "$root_span_id" ]; then
+    break
+  fi
+  
+  if [ $retry_count -ge $max_retries ]; then
+    echo "OTEL: No trace context found after ${max_retries} retries, skipping step span"
+    # Use a temporary key for skipped events without trace_id
+    skip_key="skipped_$(date +%s%N | head -c 13)_step_${LUNAR_CI_STEP_INDEX:-unknown}"
+    debug_collect ".ci.debug.step_start.$skip_key.status" "skipped_no_context" \
+      ".ci.debug.step_start.$skip_key.step_index" "${LUNAR_CI_STEP_INDEX:-}" \
+      ".ci.debug.step_start.$skip_key.retries" "$retry_count"
+    exit 0
+  fi
+  
+  sleep $retry_delay
+  retry_count=$((retry_count + 1))
+done
+
+# Generate step span ID from job ID + step index
+step_span_id=$(generate_step_span_id)
+start_time=$(nanoseconds)
+
+# Store step span info for command parent lookups
+echo "$step_span_id" > "/tmp/lunar-otel-step-${LUNAR_CI_STEP_INDEX}"
+echo "$start_time" > "/tmp/lunar-otel-step-start-${LUNAR_CI_STEP_INDEX}"
+
+# Structured collection for debugging: Create step object
+debug_collect ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.step_index" "${LUNAR_CI_STEP_INDEX}" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.step_name" "${LUNAR_CI_STEP_NAME:-unknown}" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.step_span_id" "$step_span_id" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.start_time" "$start_time" \
+  ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.status" "started"
+
+# Don't send the span yet - OpenTelemetry spans are immutable
+# We'll send it once when the step completes in step-end.sh
+echo "OTEL: Started step span $step_span_id for step ${LUNAR_CI_STEP_INDEX} (span will be sent on completion)"
+

--- a/collectors/ci-otel/step-start.sh
+++ b/collectors/ci-otel/step-start.sh
@@ -37,9 +37,9 @@ done
 step_span_id=$(generate_step_span_id)
 start_time=$(nanoseconds)
 
-# Store step span info for command parent lookups
-echo "$step_span_id" > "/tmp/lunar-otel-step-${LUNAR_CI_STEP_INDEX}"
-echo "$start_time" > "/tmp/lunar-otel-step-start-${LUNAR_CI_STEP_INDEX}"
+# Store step span info for command parent lookups (scoped by job ID)
+echo "$step_span_id" > "/tmp/lunar-otel-step-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX}"
+echo "$start_time" > "/tmp/lunar-otel-step-start-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX}"
 
 # Structured collection for debugging: Create step object
 debug_collect ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.step_index" "${LUNAR_CI_STEP_INDEX}" \


### PR DESCRIPTION
## Overview

Ports the CI OpenTelemetry tracing collector from pantalasa to lunar-lib.

Instruments CI pipelines with distributed tracing for job, step, and command-level observability. Sends traces to any OTLP backend (Tempo, Jaeger, Honeycomb, etc.).

## Architecture

| Hook | Script | Purpose |
|------|--------|---------|
| `ci-before-job` | `job-start.sh` | Create root span, generate trace ID from component+job |
| `ci-after-job` | `job-end.sh` | Complete root span with duration |
| `ci-before-step` | `step-start.sh` | Create step span as child of job |
| `ci-after-step` | `step-end.sh` | Complete step span |
| `ci-before-command` | `cmd-start.sh` | Create command span as child of step |
| `ci-after-command` | `cmd-end.sh` | Complete command span with exit code |

## Why Native Runtime?

This collector uses `default_image_ci_collectors: native` — the hooks run directly on the CI runner, not in a container. This is essential because hooks execute on **every single command** in the pipeline, and container startup overhead would multiply per-command.

## Performance Testing

Tested in `pantalasa/backend` repository to validate that containerization is not viable:

| Configuration | Build Time | Notes |
|---------------|------------|-------|
| Native collector | ~2 min | ✅ Acceptable — minimal overhead |
| Containerized collector | ~10 min | ❌ Unacceptable — container pull/start per hook |

The native collector has been running in pantalasa for months with barely noticeable overhead. The containerized test confirmed that containerization adds ~5x overhead and is not viable for this use case.

## Dependencies

The user must ensure these tools are available in their CI runner environment:

| Tool | Required | Purpose |
|------|----------|---------|
| `curl` | ✅ Yes | OTLP HTTP requests to send traces |
| `jq` | ✅ Yes | JSON construction for span payloads |
| `xxd` | ⚠️ Debug only | Fallback for span ID hex encoding when debug mode enabled |

These are standard tools pre-installed on most Linux CI runners.

🤖 *This PR was implemented by an AI agent.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenTelemetry tracing support for CI pipelines, capturing traces for jobs, steps, and commands.
  * Integrated with OTLP endpoints for telemetry export with automatic Tempo fallback.
  * Optional debug mode for enhanced data collection during troubleshooting.

* **Documentation**
  * Added comprehensive documentation for the CI OpenTelemetry collector configuration and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->