### PR TITLE
Add postgresql-client to base image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -82,5 +82,7 @@ all:
 base-image:
     ARG SCRIPTS_VERSION=main-alpine
     FROM earthly/lunar-scripts:$SCRIPTS_VERSION
+    # Add postgresql-client for collectors that need to query the Hub database
+    RUN apk add --no-cache postgresql-client
     ARG VERSION=main
     SAVE IMAGE --push earthly/lunar-lib:base-$VERSION


### PR DESCRIPTION
## Summary

Adds `postgresql-client` to the `earthly/lunar-lib:base-main` image.

## Why

Several collectors need to query the Lunar Hub database (e.g., the semgrep `github-app-default-branch` collector that checks if PRs have been scanned). These collectors use `psql` to run queries. Adding it to the base image makes it available to all collectors that need it.

## Changes

- Added `apk add --no-cache postgresql-client` to the `base-image` target in Earthfile

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added postgresql-client package installation to the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->