### PR TITLE
Fix linter policy SVG icon transparency

### DIFF
--- a/policies/linter/assets/linter.svg
+++ b/policies/linter/assets/linter.svg
@@ -1,14 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <!-- Document/code file background -->
-  <rect x="12" y="4" width="40" height="52" rx="3" fill="#1D63ED"/>
-  
-  <!-- Code lines -->
-  <rect x="18" y="12" width="20" height="3" rx="1.5" fill="white"/>
-  <rect x="18" y="19" width="28" height="3" rx="1.5" fill="white" opacity="0.7"/>
-  <rect x="18" y="26" width="16" height="3" rx="1.5" fill="white" opacity="0.7"/>
-  <rect x="18" y="33" width="24" height="3" rx="1.5" fill="white" opacity="0.7"/>
-  
+  <defs>
+    <!-- Mask to cut out the circle area from the document -->
+    <mask id="doc-mask">
+      <rect width="64" height="64" fill="white"/>
+      <circle cx="48" cy="48" r="14" fill="black"/>
+    </mask>
+  </defs>
+
+  <!-- Document with circle cutout -->
+  <g mask="url(#doc-mask)">
+    <rect x="12" y="4" width="40" height="52" rx="3" fill="#1D63ED" fill-opacity="0.15" stroke="#1D63ED" stroke-width="2"/>
+    <!-- Code lines -->
+    <rect x="18" y="14" width="20" height="2.5" rx="1.25" fill="#1D63ED" fill-opacity="0.8"/>
+    <rect x="18" y="21" width="28" height="2.5" rx="1.25" fill="#1D63ED" fill-opacity="0.5"/>
+    <rect x="18" y="28" width="16" height="2.5" rx="1.25" fill="#1D63ED" fill-opacity="0.5"/>
+    <rect x="18" y="35" width="24" height="2.5" rx="1.25" fill="#1D63ED" fill-opacity="0.5"/>
+  </g>
+
   <!-- Checkmark circle (lint passed indicator) -->
-  <circle cx="48" cy="48" r="12" fill="#10B981"/>
-  <path d="M43 48 L46 51 L53 44" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="48" cy="48" r="12" fill="#1D63ED" fill-opacity="0.15" stroke="#1D63ED" stroke-width="2"/>
+  <path d="M43 48 L46 51 L53 44" stroke="#1D63ED" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
Fix the linter policy icon which renders as flat/opaque blocks on the website's dark background.

## Changes

- Replaced opaque solid fills (`fill="#1D63ED"`, `fill="white"`, `fill="#10B981"`) with transparent fills using `fill-opacity`
- Added stroke outlines matching the `#1D63ED` brand blue used by other icons
- Added an SVG `<mask>` to cut out the document shape where the checkmark circle overlaps, preventing visual clashing between layered elements

Follows the same transparency pattern used by `container.svg` and the stroke-based approach of `readme.svg`, `testing.svg`, and `vcs.svg`.

🤖 *This PR was implemented by an AI agent.*