### PR TITLE
ci-otel: gate debug logs behind LUNAR_VAR_debug flag

### DIFF
--- a/collectors/ci-otel/job-end.sh
+++ b/collectors/ci-otel/job-end.sh
@@ -9,7 +9,7 @@ start_time=$(cat /tmp/lunar-otel-job-start-time-${LUNAR_CI_JOB_ID:-unknown} 2>/d
 end_time=$(nanoseconds)
 
 if [ -z "$trace_id" ] || [ -z "$root_span_id" ] || [ -z "$start_time" ]; then
-  echo "OTEL: No trace context or start time found, skipping job end span"
+  log_debug "No trace context or start time found, skipping job end span"
   # Use a temporary key for skipped events without trace_id
   skip_key="skipped_$(date +%s%N | head -c 13)"
   debug_collect ".ci.debug.job_end.$skip_key.status" "skipped_no_context" \
@@ -19,7 +19,7 @@ if [ -z "$trace_id" ] || [ -z "$root_span_id" ] || [ -z "$start_time" ]; then
 fi
 
 # Debug: Log trace context
-echo "OTEL: job-end: trace_id=$trace_id, root_span_id=$root_span_id, job_id=${LUNAR_CI_JOB_ID:-}" >&2
+log_debug "job-end: trace_id=$trace_id, root_span_id=$root_span_id, job_id=${LUNAR_CI_JOB_ID:-}"
 
 # Build and send the final root span
 span_name="$(build_job_span_name)"

--- a/collectors/ci-otel/job-start.sh
+++ b/collectors/ci-otel/job-start.sh
@@ -24,5 +24,5 @@ debug_collect ".ci.traces.$trace_id.trace_id" "$trace_id" \
   ".ci.traces.$trace_id.start_time" "$start_time" \
   ".ci.traces.$trace_id.status" "started"
 
-echo "OTEL: Started trace $trace_id for job"
+log_debug "Started trace $trace_id for job"
 

--- a/collectors/ci-otel/step-end.sh
+++ b/collectors/ci-otel/step-end.sh
@@ -7,7 +7,7 @@ trace_id=$(cat /tmp/lunar-otel-trace-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null 
 root_span_id=$(cat /tmp/lunar-otel-root-span-id-${LUNAR_CI_JOB_ID:-unknown} 2>/dev/null || echo "")
 
 if [ -z "$trace_id" ] || [ -z "$root_span_id" ]; then
-  echo "OTEL: No trace context found, skipping step span"
+  log_debug "No trace context found, skipping step span"
   # Use a temporary key for skipped events without trace_id
   skip_key="skipped_$(date +%s%N | head -c 13)_step_${LUNAR_CI_STEP_INDEX:-unknown}"
   debug_collect ".ci.debug.step_end.$skip_key.status" "skipped_no_context" \
@@ -19,7 +19,7 @@ step_file="/tmp/lunar-otel-step-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDE
 step_start_file="/tmp/lunar-otel-step-start-${LUNAR_CI_JOB_ID:-unknown}-${LUNAR_CI_STEP_INDEX}"
 
 if [ ! -f "$step_file" ] || [ ! -f "$step_start_file" ]; then
-  echo "OTEL: No step start found for step ${LUNAR_CI_STEP_INDEX}, skipping"
+  log_debug "No step start found for step ${LUNAR_CI_STEP_INDEX}, skipping"
   # Still try to mark the step as failed/not completed if we have trace context
   debug_collect ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.step_end.status" "skipped_no_start" \
     ".ci.traces.$trace_id.debug.steps.${LUNAR_CI_STEP_INDEX}.step_end.step_index" "${LUNAR_CI_STEP_INDEX}"
@@ -31,7 +31,7 @@ start_time=$(cat "$step_start_file")
 end_time=$(nanoseconds)
 
 # Debug: Log trace context
-echo "OTEL: step-end: trace_id=$trace_id, root_span_id=$root_span_id, step_span_id=$step_span_id, step_index=${LUNAR_CI_STEP_INDEX:-}" >&2
+log_debug "step-end: trace_id=$trace_id, root_span_id=$root_span_id, step_span_id=$step_span_id, step_index=${LUNAR_CI_STEP_INDEX:-}"
 
 # Build step name with "Step" prefix, step index, then step name
 step_name="Step ${LUNAR_CI_STEP_INDEX}: ${LUNAR_CI_STEP_NAME}"
@@ -73,5 +73,5 @@ send_span \
 # Cleanup
 rm -f "$step_file" "$step_start_file"
 
-echo "OTEL: Completed step span $step_span_id for step ${LUNAR_CI_STEP_INDEX}"
+log_debug "Completed step span $step_span_id for step ${LUNAR_CI_STEP_INDEX}"
 

--- a/collectors/ci-otel/step-start.sh
+++ b/collectors/ci-otel/step-start.sh
@@ -20,7 +20,7 @@ while [ -z "$trace_id" ] || [ -z "$root_span_id" ]; do
   fi
   
   if [ $retry_count -ge $max_retries ]; then
-    echo "OTEL: No trace context found after ${max_retries} retries, skipping step span"
+    log_debug "No trace context found after ${max_retries} retries, skipping step span"
     # Use a temporary key for skipped events without trace_id
     skip_key="skipped_$(date +%s%N | head -c 13)_step_${LUNAR_CI_STEP_INDEX:-unknown}"
     debug_collect ".ci.debug.step_start.$skip_key.status" "skipped_no_context" \
@@ -50,5 +50,5 @@ debug_collect ".ci.traces.$trace_id.steps.${LUNAR_CI_STEP_INDEX}.step_index" "${
 
 # Don't send the span yet - OpenTelemetry spans are immutable
 # We'll send it once when the step completes in step-end.sh
-echo "OTEL: Started step span $step_span_id for step ${LUNAR_CI_STEP_INDEX} (span will be sent on completion)"
+log_debug "Started step span $step_span_id for step ${LUNAR_CI_STEP_INDEX} (span will be sent on completion)"
 


### PR DESCRIPTION
## Summary

All informational/debug `OTEL:` log lines in the ci-otel collector were printing unconditionally to stderr, creating noise in CI logs when not in debug mode (e.g. `OTEL: cmd-start: trace_id=...`).

## Changes

- Added a `log_debug` helper function in `otel-helpers.sh` that only prints when `LUNAR_VAR_debug=true`
- Converted all non-error log lines across all hook scripts to use `log_debug`
- Simplified existing inline debug blocks (`if debug; echo; fi`) to use the same helper
- ERROR messages remain ungated — they indicate real problems and should always be visible

## Files changed

- `otel-helpers.sh` — added `log_debug()`, gated send_span info logs
- `cmd-start.sh` — 5 info logs + 1 inline debug block
- `cmd-end.sh` — 4 info logs + 1 inline debug block
- `step-start.sh` — 2 info logs
- `step-end.sh` — 4 info logs
- `job-start.sh` — 1 info log
- `job-end.sh` — 2 info logs

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated debug logging for the CI-OTEL collector by routing all debug messages through a unified logging mechanism, replacing direct output calls with centralized debug logging for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->