### PR TITLE
Add .cicd and .github_app conventions to Component JSON docs

### DIFF
--- a/ai-context/collector-reference.md
+++ b/ai-context/collector-reference.md
@@ -586,10 +586,8 @@ name: my-collector                    # Required: Unique name (must match direct
 description: What this collector does # Required: Brief description
 author: team@example.com              # Required
 
-# Recommended: specify container image
-# Use default_image alone when plugin has no CI collectors
-# Add default_image_ci_collectors: native when plugin includes CI collectors
-default_image: earthly/lunar-scripts:1.0.0
+# Always specify a default image - use earthly/lunar-lib:base-main
+default_image: earthly/lunar-lib:base-main
 
 # === Landing page metadata (required for public plugins) ===
 landing_page:
@@ -706,21 +704,20 @@ Configure default images in `lunar-config.yml`:
 ```yaml
 version: 0
 
-default_image: earthly/lunar-scripts:1.0.0    # Used for all collectors by default
-default_image_ci_collectors: native           # Only add when you have CI collectors
+default_image: earthly/lunar-lib:base-main    # Used for all collectors by default
 
 # ... rest of configuration
 ```
 
 **Convention:**
-- Use `default_image` alone when your plugin has no CI collectors
-- Add `default_image_ci_collectors: native` only when your plugin includes CI collectors (hooks like `ci-after-command`, `ci-after-job`, etc.)
+- Always use `default_image: earthly/lunar-lib:base-main` for collectors
+- Only use `default_image_ci_collectors: native` for **performance-intensive** CI collectors that run very frequently (e.g., ci-otel which runs on every CI command). Most CI collectors should use the default image.
 
 ### The `native` Value
 
 The special value `native` explicitly opts out of containerized execution. The script runs directly on the host system.
 
-**Use `native` only for CI collectors** that need direct access to the CI environment (environment variables, build artifacts, CI tools):
+**Use `native` sparingly** — only for **performance-intensive CI collectors** that run very frequently throughout a CI pipeline (e.g., `ci-otel` which captures metrics on every command). Most collectors, including most CI collectors, should use the default container image for consistency and isolation:
 
 ```yaml
 collectors:

--- a/ai-context/component-json/conventions.md
+++ b/ai-context/component-json/conventions.md
@@ -567,48 +567,7 @@ Collectors that detect a tool in CI or auto-run a tool themselves should use con
 
 ### `.cicd` — Tool Detected in CI
 
-Use a `.cicd` sub-key when a collector **detects a command running in the CI pipeline** (via `ci-after-command` or `ci-before-command` hooks). The `.cicd` object should contain a `cmds` array with every detected invocation, each including the command string and CLI version where possible:
-
-```json
-{
-  "sca": {
-    "native": {
-      "snyk": {
-        "cicd": {
-          "cmds": [
-            {"cmd": "snyk test --all-projects", "version": "1.1302.1"},
-            {"cmd": "snyk monitor", "version": "1.1302.1"}
-          ]
-        }
-      }
-    }
-  }
-}
-```
-
-Collecting all invocations enables version assertions, discrepancy detection across CI jobs, and full audit trails. See `collectors/golang/cicd.sh` for a reference implementation.
-
-### `.github_app` — GitHub App Detection
-
-Use a `.github_app` sub-key when a collector **detects a GitHub App posting status checks** (typically via GitHub commit status API). This captures the raw status data from the GitHub App integration:
-
-```json
-{
-  "sca": {
-    "native": {
-      "snyk": {
-        "github_app": {
-          "state": "success",
-          "context": "security/snyk",
-          "target_url": "https://app.snyk.io/..."
-        }
-      }
-    }
-  }
-}
-```
-
-The `.github_app` object preserves the check state, context name, and any links to the tool's dashboard. This enables policies to verify that GitHub App integrations are running and check their status.
+Use a `.cicd` sub-key when a collector **detects a command running in the CI pipeline** (via `ci-after-command` or `ci-before-command` hooks). The `.cicd` object should contain a `cmds` array with every detected invocation, each including the command string and CLI version where possible. Collecting all invocations enables version assertions, discrepancy detection across CI jobs, and full audit trails. See `collectors/golang/cicd.sh` for a reference implementation.
 
 ### `.auto` — Tool Auto-Run by Lunar
 

--- a/ai-context/component-json/conventions.md
+++ b/ai-context/component-json/conventions.md
@@ -567,7 +567,48 @@ Collectors that detect a tool in CI or auto-run a tool themselves should use con
 
 ### `.cicd` — Tool Detected in CI
 
-Use a `.cicd` sub-key when a collector **detects a command running in the CI pipeline** (via `ci-after-command` or `ci-before-command` hooks). The `.cicd` object should contain a `cmds` array with every detected invocation, each including the command string and CLI version where possible. Collecting all invocations enables version assertions, discrepancy detection across CI jobs, and full audit trails. See `collectors/golang/cicd.sh` for a reference implementation.
+Use a `.cicd` sub-key when a collector **detects a command running in the CI pipeline** (via `ci-after-command` or `ci-before-command` hooks). The `.cicd` object should contain a `cmds` array with every detected invocation, each including the command string and CLI version where possible:
+
+```json
+{
+  "sca": {
+    "native": {
+      "snyk": {
+        "cicd": {
+          "cmds": [
+            {"cmd": "snyk test --all-projects", "version": "1.1302.1"},
+            {"cmd": "snyk monitor", "version": "1.1302.1"}
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Collecting all invocations enables version assertions, discrepancy detection across CI jobs, and full audit trails. See `collectors/golang/cicd.sh` for a reference implementation.
+
+### `.github_app` — GitHub App Detection
+
+Use a `.github_app` sub-key when a collector **detects a GitHub App posting status checks** (typically via GitHub commit status API). This captures the raw status data from the GitHub App integration:
+
+```json
+{
+  "sca": {
+    "native": {
+      "snyk": {
+        "github_app": {
+          "state": "success",
+          "context": "security/snyk",
+          "target_url": "https://app.snyk.io/..."
+        }
+      }
+    }
+  }
+}
+```
+
+The `.github_app` object preserves the check state, context name, and any links to the tool's dashboard. This enables policies to verify that GitHub App integrations are running and check their status.
 
 ### `.auto` — Tool Auto-Run by Lunar
 


### PR DESCRIPTION
Documents the conventions for:

- `.cicd.cmds` array pattern for tracking CI command invocations with versions
- `.github_app` sub-key for capturing GitHub App status check data

These patterns are being used in the Snyk collector (#22) and should be documented for consistency.

🤖