### PR TITLE
Add CI collector guidance and .cicd/.github_app conventions

### DIFF
--- a/ai-context/collector-reference.md
+++ b/ai-context/collector-reference.md
@@ -734,6 +734,8 @@ collectors:
 
 **Do not use `native` for code or cron collectors.** These should always run in containers for consistency and isolation.
 
+**Writing CI collectors for maximum compatibility:** When writing CI collectors (especially those marked `native`), keep scripts as native-bash as possible. Avoid dependencies like `jq`, `yq`, or other tools that may not be present in all CI environments. If dependencies are absolutely necessary, they can be installed via an `install.sh` script, but this adds overhead and reduces compatibility. The goal is to run reliably across GitHub Actions, GitLab CI, CircleCI, BuildKite, and other CI providers without assumptions about the environment.
+
 ### Official Image: `earthly/lunar-scripts`
 
 Lunar provides an official Docker image that includes:

--- a/ai-context/collector-reference.md
+++ b/ai-context/collector-reference.md
@@ -266,8 +266,13 @@ For `ci-before-command` and `ci-after-command` hooks:
 ```bash
 # For ci-after-command hook on "docker build -t myimage ."
 # LUNAR_CI_COMMAND is a JSON array: ["docker","build","-t","myimage","."]
-# Use jq to parse it:
+
+# Container-based collectors can use jq (available in official image):
 echo "Hooked command: $(echo "$LUNAR_CI_COMMAND" | jq -r 'join(" ")')"
+
+# Native collectors should use pure bash (no jq dependency):
+CMD_STR=$(echo "$LUNAR_CI_COMMAND" | sed 's/^\[//; s/\]$//; s/","/ /g; s/"//g')
+echo "Hooked command: $CMD_STR"
 ```
 
 ## The lunar collect Command

--- a/ai-context/component-json/conventions.md
+++ b/ai-context/component-json/conventions.md
@@ -567,7 +567,46 @@ Collectors that detect a tool in CI or auto-run a tool themselves should use con
 
 ### `.cicd` — Tool Detected in CI
 
-Use a `.cicd` sub-key when a collector **detects a command running in the CI pipeline** (via `ci-after-command` or `ci-before-command` hooks). The `.cicd` object should contain a `cmds` array with every detected invocation, each including the command string and CLI version where possible. Collecting all invocations enables version assertions, discrepancy detection across CI jobs, and full audit trails. See `collectors/golang/cicd.sh` for a reference implementation.
+Use a `.cicd` sub-key when a collector **detects a command running in the CI pipeline** (via `ci-after-command` or `ci-before-command` hooks). The `.cicd` object should contain a `cmds` array with every detected invocation, each including the command string and CLI version where possible:
+
+```json
+{
+  "lang": {
+    "go": {
+      "cicd": {
+        "cmds": [
+          {"cmd": "go test ./...", "version": "1.22.0"},
+          {"cmd": "go build -o app", "version": "1.22.0"}
+        ]
+      }
+    }
+  }
+}
+```
+
+Collecting all invocations enables version assertions, discrepancy detection across CI jobs, and full audit trails. See `collectors/golang/cicd.sh` for a reference implementation.
+
+### `.github_app` — GitHub App Detection
+
+Use a `.github_app` sub-key when a collector **detects a GitHub App posting status checks** (typically via GitHub commit status API). This captures the raw status data from the GitHub App integration:
+
+```json
+{
+  "sca": {
+    "native": {
+      "snyk": {
+        "github_app": {
+          "state": "success",
+          "context": "security/snyk",
+          "target_url": "https://app.snyk.io/..."
+        }
+      }
+    }
+  }
+}
+```
+
+The `.github_app` object preserves the check state, context name, and any links to the tool's dashboard. This enables policies to verify that GitHub App integrations are configured and check their status.
 
 ### `.auto` — Tool Auto-Run by Lunar
 
@@ -577,7 +616,8 @@ Use an `.auto` sub-key when a collector **auto-runs a tool** itself (typically v
 
 | Sub-key | When to use | Contains | Example paths |
 |---------|-------------|----------|---------------|
-| `.cicd` | Detecting commands in CI | `cmds` array (command + version), `source` | `.lang.go.cicd`, `.containers.docker.cicd` |
+| `.cicd` | Detecting commands in CI | `cmds` array (command + version) | `.lang.go.cicd`, `.sca.native.snyk.cicd` |
+| `.github_app` | Detecting GitHub App checks | Status state, context, target URL | `.sca.native.snyk.github_app` |
 | `.auto` | Auto-running a tool | Execution metadata (version, exit_code), `source` | `.sast.semgrep.auto`, `.sbom.syft.auto` |
 | *(none)* | Normalized results | Tool-agnostic data for policies | `.sca.vulnerabilities`, `.testing.coverage` |
 


### PR DESCRIPTION
Two documentation additions:

**collector-reference.md:**
- Add guidance for keeping CI collectors native-bash compatible (avoid `jq`, `yq`, etc. for maximum CI environment compatibility)

**conventions.md:**
- Document `.cicd` sub-key pattern with `cmds` array for tracking CI command invocations
- Document `.github_app` sub-key pattern for capturing GitHub App status check data
- Update summary table with new sub-keys

🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CI collector best-practices: prefer native Bash and avoid extra tooling for maximum compatibility; added explicit guidance and examples.
  * Expanded parsing examples to show both container-based and native approaches, highlighting native-Bash alternatives.
  * Added concrete component JSON examples, introduced a GitHub App status-check example, and updated convention paths for clearer CI detection and naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->