### PR TITLE
Fix golang.cicd collector: remove jq dependency for native CI

### DIFF
--- a/collectors/golang/cicd.sh
+++ b/collectors/golang/cicd.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -e
 
-# Collect Go CI/CD command information
-cmd_str=$(echo "$LUNAR_CI_COMMAND" | jq -r 'join(" ")')
-version=$(go version | awk '{print $3}' | sed 's/go//' || echo "")
+# CI collector - runs native on CI runner, avoid jq dependency
+
+# Parse LUNAR_CI_COMMAND (may be JSON array or plain string)
+if [[ "$LUNAR_CI_COMMAND" == "["* ]]; then
+  cmd_str=$(echo "$LUNAR_CI_COMMAND" | sed 's/^\[//; s/\]$//; s/","/ /g; s/"//g')
+else
+  cmd_str="$LUNAR_CI_COMMAND"
+fi
+
+version=$(go version 2>/dev/null | awk '{print $3}' | sed 's/go//' || echo "")
 
 if [[ -n "$version" ]]; then
-  jq -n \
-    --arg cmd "$cmd_str" \
-    --arg version "$version" \
-    '{
-      cmds: [{cmd: $cmd, version: $version}],
-      source: {
-        tool: "go",
-        integration: "ci"
-      }
-    }' | \
+  # Escape quotes in command for JSON
+  cmd_escaped=$(echo "$cmd_str" | sed 's/"/\\"/g')
+  echo "{\"cmds\":[{\"cmd\":\"$cmd_escaped\",\"version\":\"$version\"}],\"source\":{\"tool\":\"go\",\"integration\":\"ci\"}}" | \
     lunar collect -j ".lang.go.cicd" -
 fi


### PR DESCRIPTION
## Problem

The `golang.cicd` collector has been failing with exit code 5 since Feb 11. All 816 runs since then have failed.

## Root Cause

`cicd.sh` uses `jq` to parse `LUNAR_CI_COMMAND`, but this collector runs natively in CI (`default_image_ci_collectors: native`). When `LUNAR_CI_COMMAND` is a plain string (e.g. `go test ./...`) rather than a JSON array (`["go","test","./..."]`), `jq -r 'join(" ")'` fails with exit code 5 (parse error).

## Fix

- Replace `jq` parsing of `LUNAR_CI_COMMAND` with pure bash string manipulation (following the pattern from `snyk/cli.sh` and the collector-reference docs)
- Handle both JSON array and plain string formats
- Construct JSON output with `echo` instead of `jq -n`
- Added `2>/dev/null` to `go version` for robustness

*This fix was generated by AI.*