### PR TITLE
Move snyk running_in_prs to category level

### DIFF
--- a/collectors/snyk/lunar-collector.yml
+++ b/collectors/snyk/lunar-collector.yml
@@ -62,6 +62,7 @@ secrets:
 example_component_json: |
   {
     "sca": {
+      "running_in_prs": true,
       "source": {
         "tool": "snyk",
         "version": "1.1200.0",
@@ -69,7 +70,6 @@ example_component_json: |
       },
       "native": {
         "snyk": {
-          "running_in_prs": true,
           "github_app": {
             "state": "success",
             "context": "security/snyk",

--- a/collectors/snyk/running-in-prs.sh
+++ b/collectors/snyk/running-in-prs.sh
@@ -58,10 +58,8 @@ for CATEGORY in sca sast container_scan iac_scan; do
     RESULT=$(psql "$CONN_STRING" -t -A -c "$QUERY" 2>/dev/null) || true
 
     if [ "$RESULT" = "t" ]; then
-        # running_in_prs: proves PRs for this component are being scanned
-        # (does not imply specific timing, just that scanning capability exists)
-        jq -n '{running_in_prs: true}' | \
-            lunar collect -j ".$CATEGORY.native.snyk" -
+        # running_in_prs at category level — tool-agnostic signal that PRs are scanned
+        lunar collect -j ".$CATEGORY.running_in_prs" "true"
 
         write_snyk_source "$CATEGORY" "github_app"
     fi


### PR DESCRIPTION
Moves `.sca.native.snyk.running_in_prs` → `.sca.running_in_prs` so policies can check PR scanning regardless of which scanner produced the signal.

Aligns with the semgrep collector (#21) which writes `.sast.running_in_prs` at category level.

*This fix was generated by AI.*