### PR TITLE
Migrate CI hook matching from regex patterns to structured format

### DIFF
--- a/collectors/ci-otel/lunar-collector.yml
+++ b/collectors/ci-otel/lunar-collector.yml
@@ -74,7 +74,6 @@ collectors:
     mainBash: cmd-start.sh
     hook:
       type: ci-before-command
-      pattern: .*
     keywords: ["opentelemetry", "tracing", "ci command", "process tracing"]
 
   - name: cmd-end
@@ -84,7 +83,6 @@ collectors:
     mainBash: cmd-end.sh
     hook:
       type: ci-after-command
-      pattern: .*
     keywords: ["opentelemetry", "tracing", "ci command", "span completion"]
 
 example_component_json: |

--- a/collectors/codecov/lunar-collector.yml
+++ b/collectors/codecov/lunar-collector.yml
@@ -27,9 +27,14 @@ collectors:
       The presence of this object signals that codecov was executed. Also captures
       the Codecov CLI version when available via the codecov --version command.
     mainBash: ran.sh
-    hook:
-      type: ci-after-command
-      pattern: codecov(cli)?|bash.*codecov
+    hooks:
+      - type: ci-after-command
+        binary:
+          name_pattern: ^codecov(cli)?$
+      - type: ci-after-command
+        binary:
+          name: bash
+        args_pattern: codecov\.io/bash
     keywords: ["codecov", "coverage detection", "ci integration"]
 
   - name: results
@@ -39,9 +44,14 @@ collectors:
       calls the Codecov API with the commit SHA, and writes coverage percentage to
       .testing.coverage.percentage with full API response in .testing.coverage.native.codecov.
     mainBash: results.sh
-    hook:
-      type: ci-after-command
-      pattern: codecov(cli)?|bash.*codecov
+    hooks:
+      - type: ci-after-command
+        binary:
+          name_pattern: ^codecov(cli)?$
+      - type: ci-after-command
+        binary:
+          name: bash
+        args_pattern: codecov\.io/bash
     keywords: ["code coverage", "coverage percentage", "codecov api", "test coverage"]
 
 inputs:

--- a/collectors/golang/lunar-collector.yml
+++ b/collectors/golang/lunar-collector.yml
@@ -29,7 +29,8 @@ collectors:
     mainBash: cicd.sh
     hook:
       type: ci-before-command
-      pattern: .*\bgo\b .*
+      binary:
+        name: go
     keywords: ["go ci", "go version", "ci commands", "build tracking"]
 
   - name: test-scope
@@ -40,7 +41,10 @@ collectors:
     mainBash: test-scope.sh
     hook:
       type: ci-before-command
-      pattern: .*\bgo\b test.*
+      binary:
+        name: go
+      args:
+        - value: test
     keywords: ["go test", "test scope", "recursive tests", "package tests"]
 
   - name: test-coverage
@@ -51,7 +55,12 @@ collectors:
     mainBash: test-coverage.sh
     hook:
       type: ci-after-command
-      pattern: .*\bgo\b test.*-coverprofile.*
+      binary:
+        name: go
+      args:
+        - value: test
+        - flag: -coverprofile
+          value_pattern: .*
     keywords: ["code coverage", "go test coverage", "coverprofile", "coverage metrics"]
 
   - name: project

--- a/collectors/snyk/lunar-collector.yml
+++ b/collectors/snyk/lunar-collector.yml
@@ -52,7 +52,8 @@ collectors:
     mainBash: cli.sh
     hook:
       type: ci-after-command
-      pattern: .*\bsnyk\b.*
+      binary:
+        name: snyk
     keywords: ["snyk cli", "ci integration", "security scanning"]
 
 secrets:

--- a/collectors/syft/lunar-collector.yml
+++ b/collectors/syft/lunar-collector.yml
@@ -41,7 +41,8 @@ collectors:
     mainBash: ci.sh
     hook:
       type: ci-after-command
-      pattern: .*\bsyft\b.*
+      binary:
+        name: syft
     keywords: ["sbom", "syft", "ci detection", "cyclonedx", "spdx"]
 
 example_component_json: |


### PR DESCRIPTION
## What
Migrates 5 collectors from regex-based `pattern` matching to the new structured hook matching format using `binary` and `args` fields.

## Why
The new structured format is more explicit and maintainable than raw regexes. It also enables the agent to match hooks by binary name and argument structure rather than relying on fragile command-line pattern matching.

## How
- **ci-otel** (cmd-start, cmd-end): Removed `pattern: .*` — catch-all is now the default when no pattern/binary is specified.
- **codecov** (ran, results): Converted single `hook` with regex to `hooks` array with two entries — one matching the `codecov`/`codecovcli` binary by name, another matching `bash` with `codecov.io/bash` in args.
- **golang** (cicd, test-scope, test-coverage): Converted to `binary.name: go` with structured `args` for subcommands and flags.
- **snyk** (cli): Converted `.*\bsnyk\b.*` to `binary.name: snyk`.
- **syft** (ci): Converted `.*\bsyft\b.*` to `binary.name: syft`.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified collector detection mechanisms by replacing regex pattern matching with explicit binary-based detection across multiple CI/CD tool integrations.
  * Restructured hook configurations for more precise identification of tool invocations.
  * Removed redundant pattern definitions from core CI collectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->