### PR TITLE
Fix testing policies: fail instead of error when .testing data is missing

### DIFF
--- a/policies/testing/coverage_reported.py
+++ b/policies/testing/coverage_reported.py
@@ -36,11 +36,12 @@ def check_coverage_reported(node=None):
             ".testing.coverage",
             "Coverage data not collected. Configure a coverage tool to run in your CI pipeline."
         )
-        # Then check that percentage is reported
-        c.assert_exists(
-            ".testing.coverage.percentage",
-            "Coverage percentage not reported. Ensure your coverage tool is configured to report metrics."
-        )
+        # Only check percentage if coverage data exists (avoid error when parent path is missing)
+        if c.get_node(".testing.coverage").exists():
+            c.assert_exists(
+                ".testing.coverage.percentage",
+                "Coverage percentage not reported. Ensure your coverage tool is configured to report metrics."
+            )
     return c
 
 

--- a/policies/testing/coverage_reported.py
+++ b/policies/testing/coverage_reported.py
@@ -36,12 +36,11 @@ def check_coverage_reported(node=None):
             ".testing.coverage",
             "Coverage data not collected. Configure a coverage tool to run in your CI pipeline."
         )
-        # Only check percentage if coverage data exists (avoid error when parent path is missing)
-        if c.get_node(".testing.coverage").exists():
-            c.assert_exists(
-                ".testing.coverage.percentage",
-                "Coverage percentage not reported. Ensure your coverage tool is configured to report metrics."
-            )
+        # Then check that percentage is reported
+        c.assert_exists(
+            ".testing.coverage.percentage",
+            "Coverage percentage not reported. Ensure your coverage tool is configured to report metrics."
+        )
     return c
 
 

--- a/policies/testing/min_coverage.py
+++ b/policies/testing/min_coverage.py
@@ -37,18 +37,21 @@ def check_min_coverage(node=None):
             ".testing.coverage",
             "No coverage data collected. Configure a coverage tool to run in your CI pipeline."
         )
-        c.assert_exists(
-            ".testing.coverage.percentage",
-            "Coverage percentage not reported. Ensure your coverage tool reports metrics."
-        )
-        
-        min_coverage = float(variable_or_default("min_coverage", "80"))
-        coverage = c.get_value(".testing.coverage.percentage")
-        c.assert_greater_or_equal(
-            coverage,
-            min_coverage,
-            f"Coverage {coverage}% is below minimum {min_coverage}%"
-        )
+
+        # Only check percentage if coverage data exists (avoid ValueError)
+        if c.get_node(".testing.coverage").exists():
+            c.assert_exists(
+                ".testing.coverage.percentage",
+                "Coverage percentage not reported. Ensure your coverage tool reports metrics."
+            )
+            if c.get_node(".testing.coverage.percentage").exists():
+                min_coverage = float(variable_or_default("min_coverage", "80"))
+                coverage = c.get_value(".testing.coverage.percentage")
+                c.assert_greater_or_equal(
+                    coverage,
+                    min_coverage,
+                    f"Coverage {coverage}% is below minimum {min_coverage}%"
+                )
     return c
 
 

--- a/policies/testing/passing.py
+++ b/policies/testing/passing.py
@@ -32,24 +32,18 @@ def check_passing(node=None):
             if not c.get_node(".lang").exists():
                 c.skip("No language project detected")
         
-        # Assert test data exists - fail (not skip) if missing
-        # This ensures the score correctly reflects missing test data
-        c.assert_exists(
-            ".testing",
-            "No test execution data found. Ensure tests are configured to run in CI."
-        )
-
-        # Only check pass/fail if testing data exists (avoid ValueError)
-        if c.get_node(".testing").exists():
-            c.assert_exists(
-                ".testing.all_passing",
-                "Test pass/fail data not available. Configure your test runner to report results."
+        # Use exists() to check for test pass/fail data:
+        # - Before collectors finish: exists() raises NoDataError -> pending
+        # - After collectors finish, no data: exists() returns False -> fail
+        # - After collectors finish, has data: exists() returns True -> use real value
+        n = c.get_node(".testing.all_passing")
+        if n.exists():
+            c.assert_true(
+                n.get_value(),
+                "Tests are failing. Check CI logs for test failure details."
             )
-            if c.get_node(".testing.all_passing").exists():
-                c.assert_true(
-                    c.get_value(".testing.all_passing"),
-                    "Tests are failing. Check CI logs for test failure details."
-                )
+        else:
+            c.fail("Test pass/fail data not available. Configure your test runner to report results.")
     return c
 
 

--- a/policies/testing/passing.py
+++ b/policies/testing/passing.py
@@ -38,16 +38,18 @@ def check_passing(node=None):
             ".testing",
             "No test execution data found. Ensure tests are configured to run in CI."
         )
-        c.assert_exists(
-            ".testing.all_passing",
-            "Test pass/fail data not available. Configure your test runner to report results."
-        )
 
-        # Assert tests are passing
-        c.assert_true(
-            c.get_value(".testing.all_passing"),
-            "Tests are failing. Check CI logs for test failure details."
-        )
+        # Only check pass/fail if testing data exists (avoid ValueError)
+        if c.get_node(".testing").exists():
+            c.assert_exists(
+                ".testing.all_passing",
+                "Test pass/fail data not available. Configure your test runner to report results."
+            )
+            if c.get_node(".testing.all_passing").exists():
+                c.assert_true(
+                    c.get_value(".testing.all_passing"),
+                    "Tests are failing. Check CI logs for test failure details."
+                )
     return c
 
 


### PR DESCRIPTION
When a component has a language project but no `.testing` data in the component JSON (e.g. CI hasn't run yet), the `passing` and `min-coverage` policies were producing **error** status (ValueError from `get_value`) instead of a clean **fail**.

**Root cause:** `assert_exists(".testing", ...)` records a fail assertion but doesn't stop execution. The subsequent `get_value(".testing.all_passing")` then raises a `ValueError` because the path doesn't exist, which the framework treats as an error.

**Fix:** Guard `get_value` calls with `get_node().exists()` so they only execute when the data is present. If the data is missing, the `assert_exists` fail is the final result — clean and intentional.

*This fix was generated by AI.* 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test evaluation robustness when coverage data is unavailable, now defaults to zero instead of failing.
  * Enhanced error messaging for missing test result data.

* **Refactor**
  * Refined conditional validation logic for test coverage and passing state checks to handle edge cases more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->