### PR TITLE
Go: move file detection from native to flat booleans

### DIFF
--- a/collectors/golang/README.md
+++ b/collectors/golang/README.md
@@ -20,7 +20,7 @@ This collector writes to the following Component JSON paths:
 | `.lang.go.tests` | object | Test scope and coverage information |
 | `.lang.go.dependencies` | object | Direct and transitive dependencies |
 | `.lang.go.lint` | object | Normalized lint warnings from golangci-lint |
-| `.lang.go.native.golangci_lint` | object | Raw golangci-lint output and status |
+| `.lang.go.golangci_lint` | object | Raw golangci-lint output and status |
 
 **Note:** This collector writes Go-native coverage data to `.lang.go.tests.coverage`. For normalized cross-language coverage at `.testing.coverage`, use a dedicated coverage tool collector (CodeCov, Coveralls, etc.).
 

--- a/collectors/golang/golangci-lint.sh
+++ b/collectors/golang/golangci-lint.sh
@@ -92,4 +92,4 @@ jq -n \
     config_exists: $config_exists,
     exit_code: $exit_code,
     output: $output
-  }' | lunar collect -j ".lang.go.native.golangci_lint" -
+  }' | lunar collect -j ".lang.go.golangci_lint" -

--- a/collectors/golang/lunar-collector.yml
+++ b/collectors/golang/lunar-collector.yml
@@ -105,17 +105,15 @@ example_component_json: |
         "module": "github.com/acme/myproject",
         "version": "1.21",
         "build_systems": ["go"],
-        "native": {
-          "go_mod": { "exists": true, "version": "1.21" },
-          "go_sum": { "exists": true },
-          "vendor": { "exists": false },
-          "goreleaser": { "exists": true },
-          "golangci_lint": {
-            "passed": false,
-            "config_exists": true,
-            "exit_code": 1,
-            "output": "main.go:42:5: unused variable 'x' (unused)"
-          }
+        "go_mod_exists": true,
+        "go_sum_exists": true,
+        "vendor_exists": false,
+        "goreleaser_exists": true,
+        "golangci_lint": {
+          "passed": false,
+          "config_exists": true,
+          "exit_code": 1,
+          "output": "main.go:42:5: unused variable 'x' (unused)"
         },
         "source": { "tool": "go", "integration": "code" },
         "cicd": {

--- a/collectors/golang/test-coverage.sh
+++ b/collectors/golang/test-coverage.sh
@@ -40,7 +40,7 @@ if [[ -n "$coverage_pct" ]]; then
   lunar collect ".lang.go.tests.coverage.profile_path" "$coverprofile_path"
 
   # Collect raw profile content as a string via stdin
-  cat "$coverprofile_path" | lunar collect ".lang.go.tests.coverage.native.profile" -
+  cat "$coverprofile_path" | lunar collect ".lang.go.tests.coverage.profile" -
 
   # Source metadata
   lunar collect ".lang.go.tests.coverage.source.tool" "go cover" \

--- a/policies/golang/README.md
+++ b/policies/golang/README.md
@@ -26,12 +26,12 @@ This policy reads from the following Component JSON paths:
 | Path | Type | Provided By |
 |------|------|-------------|
 | `.lang.go` | object | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
-| `.lang.go.native.go_mod.exists` | boolean | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
-| `.lang.go.native.go_sum.exists` | boolean | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
+| `.lang.go.go_mod_exists` | boolean | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
+| `.lang.go.go_sum_exists` | boolean | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
 | `.lang.go.version` | string | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
 | `.lang.go.tests.scope` | string | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
 | `.lang.go.cicd.cmds` | array | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
-| `.lang.go.native.vendor.exists` | boolean | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
+| `.lang.go.vendor_exists` | boolean | [`golang`](https://github.com/earthly/lunar-lib/tree/main/collectors/golang) collector |
 
 ## Installation
 
@@ -59,11 +59,9 @@ policies:
     "go": {
       "module": "github.com/acme/myproject",
       "version": "1.22",
-      "native": {
-        "go_mod": { "exists": true },
-        "go_sum": { "exists": true },
-        "vendor": { "exists": false }
-      },
+      "go_mod_exists": true,
+      "go_sum_exists": true,
+      "vendor_exists": false,
       "tests": {
         "scope": "recursive"
       }
@@ -79,10 +77,8 @@ policies:
   "lang": {
     "go": {
       "version": "1.19",
-      "native": {
-        "go_mod": { "exists": false },
-        "go_sum": { "exists": false }
-      }
+      "go_mod_exists": false,
+      "go_sum_exists": false
     }
   }
 }

--- a/policies/golang/go_mod_exists.py
+++ b/policies/golang/go_mod_exists.py
@@ -9,7 +9,7 @@ def check_go_mod_exists(node=None):
         if not go.exists():
             c.skip("Not a Go project")
 
-        go_mod = go.get_node(".native.go_mod.exists")
+        go_mod = go.get_node(".go_mod_exists")
         if not go_mod.exists():
             c.skip("Go module data not available - ensure golang collector has run")
 

--- a/policies/golang/go_sum_exists.py
+++ b/policies/golang/go_sum_exists.py
@@ -9,7 +9,7 @@ def check_go_sum_exists(node=None):
         if not go.exists():
             c.skip("Not a Go project")
 
-        go_sum = go.get_node(".native.go_sum.exists")
+        go_sum = go.get_node(".go_sum_exists")
         if not go_sum.exists():
             c.skip("Go module data not available - ensure golang collector has run")
 

--- a/policies/golang/vendoring.py
+++ b/policies/golang/vendoring.py
@@ -15,7 +15,7 @@ def check_vendoring(mode=None, node=None):
         if mode == "none":
             c.skip("Vendoring check disabled (vendoring_mode=none)")
 
-        vendor_node = go.get_node(".native.vendor.exists")
+        vendor_node = go.get_node(".vendor_exists")
         vendor_exists = vendor_node.get_value() if vendor_node.exists() else False
 
         if mode == "required":


### PR DESCRIPTION
Move file existence booleans from `.lang.go.native.go_mod.exists` pattern to flat `.lang.go.go_mod_exists` pattern, matching the Java collector convention.

### Changes
- **project.sh**: Flat booleans at `.lang.go` level instead of `.native` wrapper
- **golangci-lint.sh**: Moved from `.lang.go.native.golangci_lint` to `.lang.go.golangci_lint`
- **test-coverage.sh**: Moved profile from `.native.profile` to `.profile`
- **Policies**: Updated `go_mod_exists`, `go_sum_exists`, `vendoring` to read new paths
- **READMEs**: Updated examples and required data paths

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the Go collector data structure by flattening nested fields—moved from a nested "native" object to direct top-level boolean flags for Go project metadata (module existence, sum file presence, vendor directory, and Goreleaser configuration).
  * Updated corresponding policy checks to reference the new simplified data paths throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->