### PR TITLE
Node.js: move file detection from native to flat booleans

### DIFF
--- a/collectors/nodejs/lunar-collector.yml
+++ b/collectors/nodejs/lunar-collector.yml
@@ -73,17 +73,15 @@ example_component_json: |
       "nodejs": {
         "version": "20.11.0",
         "build_systems": ["npm"],
-        "native": {
-          "package_json": { "exists": true },
-          "package_lock": { "exists": true },
-          "yarn_lock": { "exists": false },
-          "pnpm_lock": { "exists": false },
-          "tsconfig": { "exists": true },
-          "eslint_configured": true,
-          "prettier_configured": false,
-          "engines_node": ">=18",
-          "monorepo": { "type": "workspaces" }
-        },
+        "package_json_exists": true,
+        "package_lock_exists": true,
+        "yarn_lock_exists": false,
+        "pnpm_lock_exists": false,
+        "tsconfig_exists": true,
+        "eslint_configured": true,
+        "prettier_configured": false,
+        "engines_node": ">=18",
+        "monorepo": { "type": "workspaces" },
         "source": { "tool": "node", "integration": "code" },
         "cicd": {
           "cmds": [{ "cmd": "npm test", "version": "20.11.0" }],

--- a/collectors/nodejs/project.sh
+++ b/collectors/nodejs/project.sh
@@ -99,17 +99,15 @@ jq -n \
     --arg monorepo_type "$monorepo_type" \
     '{
         build_systems: $build_systems,
-        native: ({
-            package_json: { exists: $package_json_exists },
-            package_lock: { exists: $package_lock_exists },
-            yarn_lock: { exists: $yarn_lock_exists },
-            pnpm_lock: { exists: $pnpm_lock_exists },
-            tsconfig: { exists: $tsconfig_exists },
-            eslint_configured: $eslint_configured,
-            prettier_configured: $prettier_configured,
-            engines_node: (if $engines_node != "" then $engines_node else null end),
-            monorepo: (if $monorepo_type != "" then {type: $monorepo_type} else null end)
-        } | with_entries(select(.value != null))),
+        package_json_exists: $package_json_exists,
+        package_lock_exists: $package_lock_exists,
+        yarn_lock_exists: $yarn_lock_exists,
+        pnpm_lock_exists: $pnpm_lock_exists,
+        tsconfig_exists: $tsconfig_exists,
+        eslint_configured: $eslint_configured,
+        prettier_configured: $prettier_configured,
+        engines_node: (if $engines_node != "" then $engines_node else null end),
+        monorepo: (if $monorepo_type != "" then {type: $monorepo_type} else null end),
         source: {
             tool: "node",
             integration: "code"

--- a/policies/nodejs/README.md
+++ b/policies/nodejs/README.md
@@ -25,11 +25,11 @@ This policy reads from the following Component JSON paths:
 | Path | Type | Provided By |
 |------|------|-------------|
 | `.lang.nodejs` | object | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
-| `.lang.nodejs.native.package_lock.exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
-| `.lang.nodejs.native.yarn_lock.exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
-| `.lang.nodejs.native.pnpm_lock.exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
-| `.lang.nodejs.native.tsconfig.exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
-| `.lang.nodejs.native.engines_node` | string | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
+| `.lang.nodejs.package_lock_exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
+| `.lang.nodejs.yarn_lock_exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
+| `.lang.nodejs.pnpm_lock_exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
+| `.lang.nodejs.tsconfig_exists` | boolean | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
+| `.lang.nodejs.engines_node` | string | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
 | `.lang.nodejs.version` | string | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
 | `.lang.nodejs.cicd.cmds` | array | [`nodejs`](https://github.com/earthly/lunar-lib/tree/main/collectors/nodejs) collector |
 
@@ -59,11 +59,9 @@ policies:
   "lang": {
     "nodejs": {
       "version": "20.11.0",
-      "native": {
-        "package_lock": { "exists": true },
-        "tsconfig": { "exists": true },
-        "engines_node": ">=18"
-      }
+      "package_lock_exists": true,
+      "tsconfig_exists": true,
+      "engines_node": ">=18"
     }
   }
 }
@@ -76,12 +74,10 @@ policies:
   "lang": {
     "nodejs": {
       "version": "16.20.0",
-      "native": {
-        "package_lock": { "exists": false },
-        "yarn_lock": { "exists": false },
-        "pnpm_lock": { "exists": false },
-        "tsconfig": { "exists": false }
-      }
+      "package_lock_exists": false,
+      "yarn_lock_exists": false,
+      "pnpm_lock_exists": false,
+      "tsconfig_exists": false
     }
   }
 }

--- a/policies/nodejs/checks/engines_pinned.py
+++ b/policies/nodejs/checks/engines_pinned.py
@@ -9,7 +9,7 @@ def check_engines_pinned(node=None):
         if not nodejs.exists():
             c.skip("Not a Node.js project")
 
-        engines_node = nodejs.get_node(".native.engines_node")
+        engines_node = nodejs.get_node(".engines_node")
         if not engines_node.exists():
             c.fail(
                 "engines.node is not set in package.json. "

--- a/policies/nodejs/checks/lockfile_exists.py
+++ b/policies/nodejs/checks/lockfile_exists.py
@@ -9,13 +9,9 @@ def check_lockfile_exists(node=None):
         if not nodejs.exists():
             c.skip("Not a Node.js project")
 
-        native = nodejs.get_node(".native")
-        if not native.exists():
-            c.skip("Node.js project data not available")
-
-        package_lock = native.get_value_or_default(".package_lock.exists", False)
-        yarn_lock = native.get_value_or_default(".yarn_lock.exists", False)
-        pnpm_lock = native.get_value_or_default(".pnpm_lock.exists", False)
+        package_lock = nodejs.get_value_or_default(".package_lock_exists", False)
+        yarn_lock = nodejs.get_value_or_default(".yarn_lock_exists", False)
+        pnpm_lock = nodejs.get_value_or_default(".pnpm_lock_exists", False)
 
         c.assert_true(
             package_lock or yarn_lock or pnpm_lock,

--- a/policies/nodejs/checks/typescript_configured.py
+++ b/policies/nodejs/checks/typescript_configured.py
@@ -9,7 +9,7 @@ def check_typescript_configured(node=None):
         if not nodejs.exists():
             c.skip("Not a Node.js project")
 
-        tsconfig = nodejs.get_node(".native.tsconfig.exists")
+        tsconfig = nodejs.get_node(".tsconfig_exists")
         if not tsconfig.exists():
             c.skip("TypeScript detection data not available")
 


### PR DESCRIPTION
Move file existence booleans from `.lang.nodejs.native.package_lock.exists` pattern to flat `.lang.nodejs.package_lock_exists` pattern, matching the Java collector convention.

### Changes
- **project.sh**: Flat booleans at `.lang.nodejs` level instead of `.native` wrapper
- **Policies**: Updated `lockfile_exists`, `typescript_configured`, `engines_pinned` to read new paths
- **READMEs**: Updated examples and required data paths

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured Node.js collector output to use a flatter data structure. Project configuration metadata is now organized as top-level fields instead of nested objects, improving data accessibility and simplifying integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->