### PR TITLE
Docs: clarify flat booleans vs .native for language collectors

### DIFF
--- a/ai-context/component-json/conventions.md
+++ b/ai-context/component-json/conventions.md
@@ -283,6 +283,8 @@ While normalization is ideal, sometimes it's impractical or lossy. Use the `.nat
 3. **Raw data is valuable** — Policies may need tool-specific fields
 4. **Incremental adoption** — Collect raw now, normalize later
 
+> **Note:** `.native` is for tool-specific output. Simple file detection booleans (e.g., `pom_xml_exists`, `requirements_txt_exists`) are not tool-specific output and belong directly on their parent object, not under `.native`.
+
 ### The `.native` Pattern
 
 Place normalized data at the category level, raw data under `.native.<format>` or `.native.<tool>`:


### PR DESCRIPTION
The ai-context conventions doc didn't explicitly state that language collectors should use flat boolean fields at `.lang.<language>` level for file detection, not `.native`. This led to Go, Node.js, and Python collectors all using the wrong pattern.

Adds a new section **"File Detection and Tool Config: Flat Booleans, Not `.native`"** with:
- ✅ Good example (flat booleans)
- ❌ Bad example (`.native` with `{exists: bool}`)
- Guidance on when `.native` IS appropriate (raw tool output, build-system specifics)

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified conventions for organizing tool-specific output vs. parent-level fields, adding notes to prevent placing simple file-detection flags under tool-specific sections. Updated multiple documentation spots with guidance and examples to reduce common structural misconfigurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->