### PR TITLE
Fix: replace ValueError with c.fail() in security policy max_severity checks

### DIFF
--- a/policies/iac-scan/max_severity.py
+++ b/policies/iac-scan/max_severity.py
@@ -18,13 +18,11 @@ def main(node=None):
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
 
-        c.assert_exists(
-            ".iac_scan",
-            "No IaC scan data found. Ensure a scanner (Checkov, tfsec, etc.) is configured.",
-        )
-
         scan_node = c.get_node(".iac_scan")
-        
+        if not scan_node.exists():
+            c.fail("No IaC scan data found. Ensure a scanner (Checkov, tfsec, etc.) is configured.")
+            return c
+
         # Get the index of min_severity to know which severities to check
         severity_index = SEVERITY_ORDER.index(min_severity)
         severities_to_check = SEVERITY_ORDER[:severity_index + 1]
@@ -47,7 +45,8 @@ def main(node=None):
                     c.fail(f"{severity.capitalize()} IaC misconfigurations detected ({count} found)")
                     return c
 
-        # If we get here with no data found, fail
+        # If scan data exists but has no findings/summary, that's a collector
+        # bug — raise ValueError deliberately so it surfaces as a crash.
         has_any_data = False
         for severity in severities_to_check:
             if scan_node.get_node(f".summary.has_{severity}").exists():
@@ -56,7 +55,7 @@ def main(node=None):
             if scan_node.get_node(f".findings.{severity}").exists():
                 has_any_data = True
                 break
-        
+
         if not has_any_data:
             raise ValueError(
                 "Finding counts not available. Ensure collector reports .iac_scan.findings or .iac_scan.summary."

--- a/policies/sca/max_severity.py
+++ b/policies/sca/max_severity.py
@@ -18,13 +18,11 @@ def main(node=None):
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
 
-        c.assert_exists(
-            ".sca",
-            "No SCA scanning data found. Ensure a scanner (Snyk, Semgrep, etc.) is configured.",
-        )
-
         sca_node = c.get_node(".sca")
-        
+        if not sca_node.exists():
+            c.fail("No SCA scanning data found. Ensure a scanner (Snyk, Semgrep, etc.) is configured.")
+            return c
+
         # Get the index of min_severity to know which severities to check
         severity_index = SEVERITY_ORDER.index(min_severity)
         severities_to_check = SEVERITY_ORDER[:severity_index + 1]
@@ -47,7 +45,8 @@ def main(node=None):
                     c.fail(f"{severity.capitalize()} vulnerability findings detected ({count} found)")
                     return c
 
-        # If we get here with no data found, fail
+        # If scan data exists but has no findings/summary, that's a collector
+        # bug — raise ValueError deliberately so it surfaces as a crash.
         has_any_data = False
         for severity in severities_to_check:
             if sca_node.get_node(f".summary.has_{severity}").exists():
@@ -56,7 +55,7 @@ def main(node=None):
             if sca_node.get_node(f".vulnerabilities.{severity}").exists():
                 has_any_data = True
                 break
-        
+
         if not has_any_data:
             raise ValueError(
                 "Vulnerability counts not available. Ensure collector reports .sca.vulnerabilities or .sca.summary."


### PR DESCRIPTION
## Problem

When `.iac_scan`/`.sca`/`.sast`/`.container_scan` data is missing, the `max_severity` policies crash with an unhandled `ValueError` (ERROR status) instead of producing a clean FAIL result.

This happens because `assert_exists()` records a failure but **does not stop execution**. The code continues to iterate over a non-existent node, finds no data, and hits `raise ValueError("Finding counts not available...")` — overwriting the FAIL with an ERROR.

**Note:** This is complementary to #58 (which added skip gates for non-applicable categories). The skip gate handles the case where the *prerequisite category* is missing (e.g., no `.iac` → skip). This PR handles the case where the prerequisite exists but the *scan data* is missing (e.g., `.iac` exists but `.iac_scan` does not → clean FAIL instead of ERROR).

## Changes

All four `max_severity.py` files:
- Replace `assert_exists` (which does not short-circuit) with `get_node` + `exists()` + `c.fail()` + early return
- Keep `raise ValueError` only for the true edge case: scan data exists but has no findings sub-keys (collector bug)

## Affected policies
- `iac-scan/max_severity.py`
- `sca/max_severity.py`
- `sast/max_severity.py`
- `container-scan/max_severity.py`

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security scanning policies to provide explicit failure reporting when scan data is missing or incomplete, improving error visibility.
  * Improved data validation across scanning policies to detect missing findings and surface data collection issues with clear error messages instead of silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->