### PR TITLE
fix(codeowners): prevent crash when CODEOWNERS file is missing

### DIFF
--- a/policies/codeowners/catchall.py
+++ b/policies/codeowners/catchall.py
@@ -4,8 +4,11 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("catchall", "CODEOWNERS should have a default catch-all rule", node=node)
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         has_catchall = False
         for rule in c.get_node(".ownership.codeowners.rules"):

--- a/policies/codeowners/catchall.py
+++ b/policies/codeowners/catchall.py
@@ -4,8 +4,6 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("catchall", "CODEOWNERS should have a default catch-all rule", node=node)
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/max_owners.py
+++ b/policies/codeowners/max_owners.py
@@ -8,8 +8,6 @@ def main(node=None, max_owners_override=None):
         node=node,
     )
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/max_owners.py
+++ b/policies/codeowners/max_owners.py
@@ -8,8 +8,11 @@ def main(node=None, max_owners_override=None):
         node=node,
     )
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         max_owners = (
             max_owners_override

--- a/policies/codeowners/min_owners.py
+++ b/policies/codeowners/min_owners.py
@@ -8,8 +8,11 @@ def main(node=None, min_owners_override=None):
         node=node,
     )
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         min_owners = (
             min_owners_override

--- a/policies/codeowners/min_owners.py
+++ b/policies/codeowners/min_owners.py
@@ -8,8 +8,6 @@ def main(node=None, min_owners_override=None):
         node=node,
     )
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/no_empty_rules.py
+++ b/policies/codeowners/no_empty_rules.py
@@ -8,8 +8,11 @@ def main(node=None):
         node=node,
     )
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         for rule in c.get_node(".ownership.codeowners.rules"):
             pattern = rule.get_value(".pattern")

--- a/policies/codeowners/no_empty_rules.py
+++ b/policies/codeowners/no_empty_rules.py
@@ -8,8 +8,6 @@ def main(node=None):
         node=node,
     )
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/no_individuals_only.py
+++ b/policies/codeowners/no_individuals_only.py
@@ -8,8 +8,11 @@ def main(node=None):
         node=node,
     )
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         team_owners = set(c.get_value(".ownership.codeowners.team_owners"))
 

--- a/policies/codeowners/no_individuals_only.py
+++ b/policies/codeowners/no_individuals_only.py
@@ -8,8 +8,6 @@ def main(node=None):
         node=node,
     )
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/team_owners.py
+++ b/policies/codeowners/team_owners.py
@@ -8,8 +8,11 @@ def main(node=None):
         node=node,
     )
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         team_owners = c.get_value(".ownership.codeowners.team_owners")
         c.assert_true(

--- a/policies/codeowners/team_owners.py
+++ b/policies/codeowners/team_owners.py
@@ -8,8 +8,6 @@ def main(node=None):
         node=node,
     )
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/valid.py
+++ b/policies/codeowners/valid.py
@@ -4,8 +4,6 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("valid", "CODEOWNERS file should have valid syntax", node=node)
     with c:
-        # Check if CODEOWNERS exists - return early if not
-        # (get_value handles nodata properly -> PENDING if collector not done)
         if not c.get_value(".ownership.codeowners.exists"):
             c.fail("No CODEOWNERS file found")
             return c

--- a/policies/codeowners/valid.py
+++ b/policies/codeowners/valid.py
@@ -4,8 +4,11 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("valid", "CODEOWNERS file should have valid syntax", node=node)
     with c:
-        c.assert_true(c.get_value(".ownership.codeowners.exists"),
-            "No CODEOWNERS file found")
+        # Check if CODEOWNERS exists - return early if not
+        # (get_value handles nodata properly -> PENDING if collector not done)
+        if not c.get_value(".ownership.codeowners.exists"):
+            c.fail("No CODEOWNERS file found")
+            return c
 
         valid = c.get_value(".ownership.codeowners.valid")
         if valid:


### PR DESCRIPTION
## Problem

The codeowners policies were crashing with `ValueError: No data found at path .ownership.codeowners.valid` (and similar) when a repository has no CODEOWNERS file.

**Root cause:** The policies used `assert_true()` to check if the CODEOWNERS file exists, but `assert_true()` records a failure without stopping execution. This caused subsequent code to crash when trying to access paths that don't exist when there's no CODEOWNERS file.

Example from `valid.py`:
```python
c.assert_true(c.get_value(".ownership.codeowners.exists"), "No CODEOWNERS file found")
# assert_true fails but execution continues...
valid = c.get_value(".ownership.codeowners.valid")  # CRASH - path doesn't exist!
```

## Fix

Check the boolean value and return early before accessing other fields:
```python
if not c.get_value(".ownership.codeowners.exists"):
    c.fail("No CODEOWNERS file found")
    return c  # Early return!

valid = c.get_value(".ownership.codeowners.valid")  # Safe - file exists
```

The `get_value()` call properly handles nodata states (raises `NoDataError` → PENDING if collector not finished).

## Affected Policies

- `valid.py`
- `catchall.py`
- `min_owners.py`
- `max_owners.py`
- `team_owners.py`
- `no_individuals_only.py`
- `no_empty_rules.py`

## Testing

Observed on meridian-demo environment: all 7 codeowners policies were erroring on `react-native-pathjs-charts` component which has no CODEOWNERS file.

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across CODEOWNERS policy checks: missing CODEOWNERS now yields clear failure messages and early exits instead of assertion failures, producing more consistent, graceful reporting.

* **Refactor**
  * Streamlined control flow in multiple validators to handle absent CODEOWNERS files robustly while preserving existing validation behavior when the file is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->