### PR TITLE
Skip security scan policies when category is not applicable

### DIFF
--- a/policies/container-scan/executed.py
+++ b/policies/container-scan/executed.py
@@ -6,6 +6,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("executed", "Container scan must be executed", node=node)
     with c:
+        if not c.get_node(".containers").exists():
+            c.skip("No container definitions detected in this component")
+
         c.assert_exists(
             ".container_scan",
             "No container scanning data found. Ensure a scanner (Trivy, Grype, etc.) is configured.",

--- a/policies/container-scan/max_severity.py
+++ b/policies/container-scan/max_severity.py
@@ -15,6 +15,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
 
+        if not c.get_node(".containers").exists():
+            c.skip("No container definitions detected in this component")
+
         c.assert_exists(
             ".container_scan",
             "No container scan data found. Ensure a scanner (Trivy, Grype, etc.) is configured.",

--- a/policies/container-scan/max_severity.py
+++ b/policies/container-scan/max_severity.py
@@ -8,15 +8,15 @@ SEVERITY_ORDER = ["critical", "high", "medium", "low"]
 def main(node=None):
     c = Check("max-severity", "No findings at or above severity threshold", node=node)
     with c:
+        if not c.get_node(".containers").exists():
+            c.skip("No container definitions detected in this component")
+
         min_severity = variable_or_default("min_severity", "high").lower()
         
         if min_severity not in SEVERITY_ORDER:
             raise ValueError(
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
-
-        if not c.get_node(".containers").exists():
-            c.skip("No container definitions detected in this component")
 
         c.assert_exists(
             ".container_scan",

--- a/policies/container-scan/max_total.py
+++ b/policies/container-scan/max_total.py
@@ -19,6 +19,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
 
+        if not c.get_node(".containers").exists():
+            c.skip("No container definitions detected in this component")
+
         scan_node = c.get_node(".container_scan")
         if not scan_node.exists():
             c.fail("No container scanning data found. Ensure a scanner (Trivy, Grype, etc.) is configured.")

--- a/policies/container-scan/max_total.py
+++ b/policies/container-scan/max_total.py
@@ -6,6 +6,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None):
     c = Check("max-total", "Total container vulnerability findings within threshold", node=node)
     with c:
+        if not c.get_node(".containers").exists():
+            c.skip("No container definitions detected in this component")
+
         threshold_str = variable_or_default("max_total_threshold", "0")
         try:
             threshold = int(threshold_str)
@@ -18,9 +21,6 @@ def main(node=None):
             raise ValueError(
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
-
-        if not c.get_node(".containers").exists():
-            c.skip("No container definitions detected in this component")
 
         scan_node = c.get_node(".container_scan")
         if not scan_node.exists():

--- a/policies/iac-scan/executed.py
+++ b/policies/iac-scan/executed.py
@@ -6,6 +6,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("executed", "IaC scan must be executed", node=node)
     with c:
+        if not c.get_node(".iac").exists():
+            c.skip("No infrastructure as code detected in this component")
+
         c.assert_exists(
             ".iac_scan",
             "No IaC scanning data found. Ensure a scanner (Trivy, Checkov, etc.) is configured.",

--- a/policies/iac-scan/max_severity.py
+++ b/policies/iac-scan/max_severity.py
@@ -8,15 +8,15 @@ SEVERITY_ORDER = ["critical", "high", "medium", "low"]
 def main(node=None):
     c = Check("max-severity", "No findings at or above severity threshold", node=node)
     with c:
+        if not c.get_node(".iac").exists():
+            c.skip("No infrastructure as code detected in this component")
+
         min_severity = variable_or_default("min_severity", "high").lower()
         
         if min_severity not in SEVERITY_ORDER:
             raise ValueError(
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
-
-        if not c.get_node(".iac").exists():
-            c.skip("No infrastructure as code detected in this component")
 
         c.assert_exists(
             ".iac_scan",

--- a/policies/iac-scan/max_severity.py
+++ b/policies/iac-scan/max_severity.py
@@ -15,6 +15,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
 
+        if not c.get_node(".iac").exists():
+            c.skip("No infrastructure as code detected in this component")
+
         c.assert_exists(
             ".iac_scan",
             "No IaC scan data found. Ensure a scanner (Checkov, tfsec, etc.) is configured.",

--- a/policies/iac-scan/max_total.py
+++ b/policies/iac-scan/max_total.py
@@ -6,6 +6,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None):
     c = Check("max-total", "Total infrastructure security findings within threshold", node=node)
     with c:
+        if not c.get_node(".iac").exists():
+            c.skip("No infrastructure as code detected in this component")
+
         threshold_str = variable_or_default("max_total_threshold", "0")
         try:
             threshold = int(threshold_str)
@@ -18,9 +21,6 @@ def main(node=None):
             raise ValueError(
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
-
-        if not c.get_node(".iac").exists():
-            c.skip("No infrastructure as code detected in this component")
 
         scan_node = c.get_node(".iac_scan")
         if not scan_node.exists():

--- a/policies/iac-scan/max_total.py
+++ b/policies/iac-scan/max_total.py
@@ -19,6 +19,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
 
+        if not c.get_node(".iac").exists():
+            c.skip("No infrastructure as code detected in this component")
+
         scan_node = c.get_node(".iac_scan")
         if not scan_node.exists():
             c.fail("No IaC scanning data found. Ensure a scanner (Checkov, tfsec, etc.) is configured.")

--- a/policies/sast/executed.py
+++ b/policies/sast/executed.py
@@ -6,6 +6,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("executed", "SAST scan must be executed", node=node)
     with c:
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         c.assert_exists(
             ".sast",
             "No SAST scanning data found. Ensure a scanner (Semgrep, CodeQL, etc.) is configured.",

--- a/policies/sast/max_severity.py
+++ b/policies/sast/max_severity.py
@@ -8,15 +8,15 @@ SEVERITY_ORDER = ["critical", "high", "medium", "low"]
 def main(node=None):
     c = Check("max-severity", "No findings at or above severity threshold", node=node)
     with c:
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         min_severity = variable_or_default("min_severity", "high").lower()
         
         if min_severity not in SEVERITY_ORDER:
             raise ValueError(
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
-
-        if not c.get_node(".lang").exists():
-            c.skip("No programming language detected in this component")
 
         c.assert_exists(
             ".sast",

--- a/policies/sast/max_severity.py
+++ b/policies/sast/max_severity.py
@@ -15,6 +15,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
 
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         c.assert_exists(
             ".sast",
             "No SAST scanning data found. Ensure a scanner (Semgrep, CodeQL, etc.) is configured.",

--- a/policies/sast/max_total.py
+++ b/policies/sast/max_total.py
@@ -6,6 +6,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None):
     c = Check("max-total", "Total code findings within threshold", node=node)
     with c:
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         threshold_str = variable_or_default("max_total_threshold", "0")
         try:
             threshold = int(threshold_str)
@@ -18,9 +21,6 @@ def main(node=None):
             raise ValueError(
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
-
-        if not c.get_node(".lang").exists():
-            c.skip("No programming language detected in this component")
 
         sast_node = c.get_node(".sast")
         if not sast_node.exists():

--- a/policies/sast/max_total.py
+++ b/policies/sast/max_total.py
@@ -19,6 +19,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
 
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         sast_node = c.get_node(".sast")
         if not sast_node.exists():
             c.fail("No SAST scanning data found. Ensure a scanner (Semgrep, CodeQL, etc.) is configured.")

--- a/policies/sca/executed.py
+++ b/policies/sca/executed.py
@@ -6,6 +6,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("executed", "SCA scan must be executed", node=node)
     with c:
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         c.assert_exists(
             ".sca",
             "No SCA scanning data found. Ensure a scanner (Snyk, Semgrep, etc.) is configured.",

--- a/policies/sca/max_severity.py
+++ b/policies/sca/max_severity.py
@@ -15,6 +15,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
 
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         c.assert_exists(
             ".sca",
             "No SCA scanning data found. Ensure a scanner (Snyk, Semgrep, etc.) is configured.",

--- a/policies/sca/max_severity.py
+++ b/policies/sca/max_severity.py
@@ -8,15 +8,15 @@ SEVERITY_ORDER = ["critical", "high", "medium", "low"]
 def main(node=None):
     c = Check("max-severity", "No findings at or above severity threshold", node=node)
     with c:
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         min_severity = variable_or_default("min_severity", "high").lower()
         
         if min_severity not in SEVERITY_ORDER:
             raise ValueError(
                 f"Policy misconfiguration: 'min_severity' must be one of {SEVERITY_ORDER}, got '{min_severity}'"
             )
-
-        if not c.get_node(".lang").exists():
-            c.skip("No programming language detected in this component")
 
         c.assert_exists(
             ".sca",

--- a/policies/sca/max_total.py
+++ b/policies/sca/max_total.py
@@ -19,6 +19,9 @@ def main(node=None):
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
 
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         sca_node = c.get_node(".sca")
         if not sca_node.exists():
             c.fail("No SCA scanning data found. Ensure a scanner (Snyk, Semgrep, etc.) is configured.")

--- a/policies/sca/max_total.py
+++ b/policies/sca/max_total.py
@@ -6,6 +6,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None):
     c = Check("max-total", "Total vulnerability findings within threshold", node=node)
     with c:
+        if not c.get_node(".lang").exists():
+            c.skip("No programming language detected in this component")
+
         threshold_str = variable_or_default("max_total_threshold", "0")
         try:
             threshold = int(threshold_str)
@@ -18,9 +21,6 @@ def main(node=None):
             raise ValueError(
                 f"Policy misconfiguration: 'max_total_threshold' must be a positive integer, got '{threshold}'"
             )
-
-        if not c.get_node(".lang").exists():
-            c.skip("No programming language detected in this component")
 
         sca_node = c.get_node(".sca")
         if not sca_node.exists():


### PR DESCRIPTION
## Problem

Security scan policies (`iac-scan`, `container-scan`, `sast`, `sca`) would **fail** on components where the scanned category doesn't exist. For example, `iac-scan.executed` fails on a Node.js frontend that has no Terraform files — but it should **skip** since the policy isn't applicable.

## Solution

Add applicability gates before requiring scan data. Each policy family now checks for the *prerequisite data category* and skips when not relevant:

| Policy | Prerequisite | Skip message |
|--------|-------------|--------------|
| `iac-scan` | `.iac` | No infrastructure as code detected |
| `container-scan` | `.containers` | No container definitions detected |
| `sast` | `.lang` | No programming language detected |
| `sca` | `.lang` | No programming language detected |

This follows the same pattern used by `testing` and `linter` policies (which gate on `.lang` before requiring test/lint data).

### Behavior matrix

| State | Before | After |
|-------|--------|-------|
| No prerequisite data | ❌ FAIL | ⏭️ SKIP |
| Prerequisite exists, no scan data | ❌ FAIL | ❌ FAIL (unchanged) |
| Prerequisite + scan data | ✅ PASS | ✅ PASS (unchanged) |

All 3 checks per policy (`executed`, `max-severity`, `max-total`) get the same gate.

Users can still selectively apply policies via tag filtering — this is a more forgiving default.

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policies for container scanning, IaC, SAST, and SCA now detect missing prerequisites (e.g., no containers, no IaC, no detected language) and gracefully skip evaluation with a clear message, avoiding unnecessary failures and improving overall policy robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->