### PR TITLE
Migrate all plugins from lunar-scripts:1.0.0 to lunar-lib:base-main

### DIFF
--- a/collectors/ci-otel/lunar-collector.yml
+++ b/collectors/ci-otel/lunar-collector.yml
@@ -4,7 +4,7 @@ name: ci-otel
 description: Emit OpenTelemetry traces for CI pipeline runs
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 default_image_ci_collectors: native
 
 landing_page:

--- a/policies/dependencies/lunar-policy.yml
+++ b/policies/dependencies/lunar-policy.yml
@@ -4,7 +4,7 @@ name: dependencies
 description: Dependency version and security policies
 author: earthly
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Dependency Guardrails"

--- a/policies/golang/lunar-policy.yml
+++ b/policies/golang/lunar-policy.yml
@@ -4,7 +4,7 @@ name: golang
 description: Enforces Go project structure and standards
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Go Project Guardrails"

--- a/policies/java/lunar-policy.yml
+++ b/policies/java/lunar-policy.yml
@@ -4,7 +4,7 @@ name: java
 description: Enforces Java project structure and build tool standards
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Java Project Guardrails"

--- a/policies/linter/lunar-policy.yml
+++ b/policies/linter/lunar-policy.yml
@@ -4,7 +4,7 @@ name: linter
 description: Checks that linting ran and passes with acceptable warning count
 author: earthly
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Linter Guardrails"

--- a/policies/nodejs/lunar-policy.yml
+++ b/policies/nodejs/lunar-policy.yml
@@ -4,7 +4,7 @@ name: nodejs
 description: Enforces Node.js project structure and standards
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Node.js Project Guardrails"

--- a/policies/python/lunar-policy.yml
+++ b/policies/python/lunar-policy.yml
@@ -4,7 +4,7 @@ name: python
 description: Enforces Python project structure and standards
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Python Project Guardrails"

--- a/policies/sbom/lunar-policy.yml
+++ b/policies/sbom/lunar-policy.yml
@@ -4,7 +4,7 @@ name: sbom
 description: Enforces SBOM existence, license compliance, completeness, and format
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "SBOM Guardrails"

--- a/policies/testing/lunar-policy.yml
+++ b/policies/testing/lunar-policy.yml
@@ -4,7 +4,7 @@ name: testing
 description: Validates that tests are executed, pass, and meet coverage thresholds
 author: support@earthly.dev
 
-default_image: earthly/lunar-scripts:1.0.0
+default_image: earthly/lunar-lib:base-main
 
 landing_page:
   display_name: "Testing Guardrails"

--- a/policies/ticket/lunar-policy.yml
+++ b/policies/ticket/lunar-policy.yml
@@ -4,6 +4,8 @@ name: ticket
 description: Enforce issue tracker ticket hygiene in PRs
 author: support@earthly.dev
 
+default_image: earthly/lunar-lib:base-main
+
 landing_page:
   display_name: "Ticket Guardrails"
   long_description: |

--- a/policies/vcs/lunar-policy.yml
+++ b/policies/vcs/lunar-policy.yml
@@ -4,6 +4,8 @@ name: vcs
 description: Version control system (VCS) best practices and security policies
 author: earthly
 
+default_image: earthly/lunar-lib:base-main
+
 landing_page:
   display_name: "VCS Guardrails"
   long_description: |


### PR DESCRIPTION
## Summary

Replace the old `earthly/lunar-scripts:1.0.0` image with `earthly/lunar-lib:base-main` across all collector and policy manifests. The `lunar-scripts` image is an older problematic version that may be contributing to performance issues.

### Changes

**Replaced `lunar-scripts:1.0.0` → `lunar-lib:base-main` (9 files):**
- `policies/python/lunar-policy.yml`
- `policies/java/lunar-policy.yml`
- `policies/nodejs/lunar-policy.yml`
- `policies/sbom/lunar-policy.yml`
- `policies/testing/lunar-policy.yml`
- `policies/golang/lunar-policy.yml`
- `policies/dependencies/lunar-policy.yml`
- `policies/linter/lunar-policy.yml`
- `collectors/ci-otel/lunar-collector.yml`

**Added missing `default_image` (2 files):**
- `policies/vcs/lunar-policy.yml` — had no `default_image` set
- `policies/ticket/lunar-policy.yml` — had no `default_image` set

### Note on `collectors/claude`

The claude collector uses `image: +image` (a custom Earthfile-built image) instead of `default_image`. This means it builds its own image rather than referencing a pre-built one. Should this follow the same pattern as other custom-image collectors (e.g. `earthly/lunar-lib:claude-main`) for consistency?

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image across all policies and the CI collector to a newer base image version. This affects the execution environment for dependencies, language tooling, linting, testing, and SBOM analysis policies. The updated base image may provide additional tools and environment changes for policy execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->