### PR TITLE
Add custom Docker image for policies with Python dependencies

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -87,6 +87,7 @@ all:
     BUILD --pass-args ./collectors/nodejs+image
     BUILD --pass-args ./collectors/syft+image
     BUILD --pass-args ./catalogers/github-org+image
+    BUILD --pass-args ./policies/dependencies+image
 
 base-image:
     ARG SCRIPTS_VERSION=main-alpine

--- a/policies/dependencies/Earthfile
+++ b/policies/dependencies/Earthfile
@@ -1,0 +1,11 @@
+VERSION 0.8
+
+image:
+    FROM --pass-args ../../+base-image
+
+    # Install Python dependencies
+    COPY requirements.txt .
+    RUN pip install --no-cache-dir -r requirements.txt
+
+    ARG VERSION=main
+    SAVE IMAGE --push earthly/lunar-lib:policy-dependencies-$VERSION

--- a/policies/dependencies/lunar-policy.yml
+++ b/policies/dependencies/lunar-policy.yml
@@ -4,7 +4,7 @@ name: dependencies
 description: Dependency version and security policies
 author: earthly
 
-default_image: earthly/lunar-lib:base-main
+default_image: earthly/lunar-lib:policy-dependencies-main
 
 landing_page:
   display_name: "Dependency Guardrails"


### PR DESCRIPTION
## Summary

The `dependencies` policy uses the `semver` Python package which isn't available in the base image. Currently this means the dependency must be downloaded every time the policy runs.

This PR adds an Earthfile for the `dependencies` policy that extends the base image and pre-installs Python dependencies from `requirements.txt` at build time, following the same pattern collectors use for custom images (e.g., `collectors/golang/Earthfile`, `collectors/syft/Earthfile`).

## Changes

- **`policies/dependencies/Earthfile`** — New file. Builds `earthly/lunar-lib:policy-dependencies-$VERSION` extending `+base-image` with `pip install` of `requirements.txt` (`semver==3.0.2`)
- **`policies/dependencies/lunar-policy.yml`** — Updated `default_image` from `earthly/lunar-lib:base-main` to `earthly/lunar-lib:policy-dependencies-main`
- **`Earthfile`** — Added `BUILD --pass-args ./policies/dependencies+image` to the `+all` target so CI builds and pushes the image

## Notes

Audited all other policies — `dependencies` is the only one with a non-standard Python dependency. All language-specific version policies (Go, Java, Node.js, Python) use simple tuple-based version comparison and don't need `semver`. The pattern is extensible: any future policy needing custom deps can add its own Earthfile the same way.

*This PR was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to include a new dependencies policy image in the aggregated build sequence.
  * Added new dependencies policy image configuration with Python package management.
  * Updated default image reference for the dependencies policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->