### PR TITLE
Fix incorrect requires in scanner policy manifests

### DIFF
--- a/policies/container-scan/lunar-policy.yml
+++ b/policies/container-scan/lunar-policy.yml
@@ -15,7 +15,7 @@ landing_page:
   icon: "assets/container-scan.svg"
   status: "stable"
   requires:
-    - slug: "dockerfile"
+    - slug: "docker"
       type: "collector"
       reason: "Provides container definitions used as the applicability gate"
     - slug: "snyk"

--- a/policies/container-scan/lunar-policy.yml
+++ b/policies/container-scan/lunar-policy.yml
@@ -15,9 +15,12 @@ landing_page:
   icon: "assets/container-scan.svg"
   status: "stable"
   requires:
-    - slug: "github"
+    - slug: "dockerfile"
       type: "collector"
-      reason: "Provides container scan data via GitHub App integrations"
+      reason: "Provides container definitions used as the applicability gate"
+    - slug: "snyk"
+      type: "collector"
+      reason: "Provides container scan results via Snyk Container"
   related: []
 
 policies:

--- a/policies/iac-scan/lunar-policy.yml
+++ b/policies/iac-scan/lunar-policy.yml
@@ -15,9 +15,9 @@ landing_page:
   icon: "assets/iac-scan.svg"
   status: "stable"
   requires:
-    - slug: "github"
+    - slug: "snyk"
       type: "collector"
-      reason: "Provides IaC scan data via GitHub App integrations"
+      reason: "Provides IaC scan results via Snyk IaC"
   related: []
 
 policies:

--- a/policies/sast/lunar-policy.yml
+++ b/policies/sast/lunar-policy.yml
@@ -15,9 +15,12 @@ landing_page:
   icon: "assets/sast.svg"
   status: "stable"
   requires:
-    - slug: "github"
+    - slug: "semgrep"
       type: "collector"
-      reason: "Provides SAST data via GitHub App integrations (Semgrep, CodeQL)"
+      reason: "Provides SAST scan results via Semgrep Code"
+    - slug: "snyk"
+      type: "collector"
+      reason: "Provides SAST scan results via Snyk Code"
   related: []
 
 policies:

--- a/policies/sca/lunar-policy.yml
+++ b/policies/sca/lunar-policy.yml
@@ -15,9 +15,12 @@ landing_page:
   icon: "assets/sca.svg"
   status: "stable"
   requires:
-    - slug: "github"
+    - slug: "snyk"
       type: "collector"
-      reason: "Provides SCA data via GitHub App integrations (Snyk, Dependabot)"
+      reason: "Provides SCA scan results via Snyk Open Source"
+    - slug: "semgrep"
+      type: "collector"
+      reason: "Provides SCA scan results via Semgrep Supply Chain"
   related: []
 
 policies:


### PR DESCRIPTION
All four scanner policies (container-scan, sca, sast, iac-scan) incorrectly listed the `github` collector as a dependency in their `landing_page.requires` field. None of these policies actually depend on the github collector.

### Changes

Updated `requires` to reference the actual collectors that write to each policy's Component JSON paths:

| Policy | Before | After |
|--------|--------|-------|
| **container-scan** | github | dockerfile + snyk |
| **sca** | github | snyk + semgrep |
| **sast** | github | semgrep + snyk |
| **iac-scan** | github | snyk |

### Why

- `.container_scan` is written by the **snyk** collector (`snyk container`), not github
- `.sca` is written by **snyk** and **semgrep** collectors
- `.sast` is written by **semgrep** and **snyk** collectors
- `.iac_scan` is written by the **snyk** collector (`snyk iac`), not github
- `.containers` (applicability gate for container-scan) is written by the **dockerfile** collector

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Container scanning now uses Dockerfile as the applicability gate and adds Snyk as a collector.
  * IaC policies now reference Snyk as a collector for IaC scan results.
  * SAST policies replace GitHub with Semgrep and add Snyk as an additional SAST collector.
  * SCA policies replace GitHub with Snyk and introduce Semgrep as an additional SCA collector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->