### PR TITLE
fix: k8s collector should not write empty data when no manifests found

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -83,6 +83,7 @@ all:
     BUILD --pass-args ./collectors/ast-grep+image
     BUILD --pass-args ./collectors/claude+image
     BUILD --pass-args ./collectors/docker+image
+    BUILD --pass-args ./collectors/k8s+image
     BUILD --pass-args ./collectors/golang+image
     BUILD --pass-args ./collectors/nodejs+image
     BUILD --pass-args ./collectors/syft+image

--- a/collectors/k8s/Earthfile
+++ b/collectors/k8s/Earthfile
@@ -11,6 +11,10 @@ image:
         mv kubeconform /usr/local/bin/ && \
         chmod +x /usr/local/bin/kubeconform
 
+    # Install GNU parallel for parallel file processing
+    RUN apk add --no-cache parallel && \
+        mkdir -p ~/.parallel && touch ~/.parallel/will-cite
+
     ARG VERSION=main
     SAVE IMAGE --push earthly/lunar-lib:k8s-$VERSION
 

--- a/collectors/k8s/lunar-collector.yml
+++ b/collectors/k8s/lunar-collector.yml
@@ -4,7 +4,7 @@ name: k8s
 description: Parses Kubernetes manifests and collects workload, PDB, and HPA metadata
 author: earthly
 
-default_image: earthly/lunar-lib:base-main
+default_image: earthly/lunar-lib:k8s-main
 
 landing_page:
   display_name: "Kubernetes Collector"
@@ -39,7 +39,7 @@ collectors:
 inputs:
   find_command:
     description: Command to find K8s manifest files (must output one file path per line)
-    default: "git ls-files '*.yaml' '*.yml'"
+    default: "find . -type f \\( -name '*.yaml' -o -name '*.yml' \\)"
 
 example_component_json: |
   {


### PR DESCRIPTION
## Problem

When a repository has no Kubernetes manifests or Dockerfiles, the respective collectors were still writing empty data to Component JSON, polluting it for repos that have nothing to do with these technologies.

Additionally, the k8s collector had several issues preventing it from working when referenced from `github://` (as opposed to a local copy):
- `default_image` was `base-main` which lacks `kubeconform` and `parallel`
- Used `git ls-files` but hub containers do not have a `.git` directory
- Was not included in the root Earthfile `all` target

## Changes

### k8s collector
- **Skip empty data** — check `manifests` array length before writing
- **Use custom image** (`k8s-main`) with `kubeconform` and `parallel` installed
- **Switch to `find`** instead of `git ls-files` for manifest discovery (hub containers lack `.git`)
- **Add to root `all` target** so the image is built by CI

### docker collector
- **Skip empty data** — check results array length before writing

### Already correct
- **terraform** — already exits early when no `.tf` files found

## Test Results (cronos demo)

### Positive case — `pantalasa-cronos/backend` (has k8s manifests in `deploy/`)

```
16:29:25 | exit=0 | elapsed=13s | data_records=2 ✅
```
Data written: manifests (argocd/application.yaml, deploy/*.yaml, backstage/other.yaml), 1 HPA, 1 workload, source metadata (kubeconform 0.6.7).

### Negative case — `pantalasa-cronos/rust-service` (no k8s, no Dockerfiles)

| Collector | Result |
|-----------|--------|
| `k8s.k8s` | ✅ exit=0, no data written |
| `docker.dockerfile` | ✅ exit=0, no data written |

### Mixed case — `pantalasa-cronos/frontend` (has Dockerfiles, no k8s)

| Collector | Result |
|-----------|--------|
| `docker.dockerfile` | ✅ exit=0, data written (definitions + source) |
| `k8s.k8s` | ✅ exit=0, no data written |

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Docker and Kubernetes collectors now implement conditional execution, processing only when relevant files are detected.
  * Improved manifest file discovery with enhanced detection patterns for more reliable results.

* **Performance**
  * Optimized build infrastructure for Kubernetes collector with additional tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->