### PR TITLE
Make required-labels check per-Dockerfile instead of global

### DIFF
--- a/policies/container/required_labels.py
+++ b/policies/container/required_labels.py
@@ -3,6 +3,13 @@
 from lunar_policy import Check, variable_or_default
 
 
+def _normalize_path(path):
+    """Strip leading ./ for consistent matching."""
+    if path and path.startswith("./"):
+        return path[2:]
+    return path
+
+
 def main():
     with Check("required-labels", "Containers should have required labels") as c:
         required_str = variable_or_default("required_labels", "")
@@ -11,31 +18,59 @@ def main():
         if not required:
             return
 
-        # Collect all labels from Dockerfile definitions
-        dockerfile_labels = {}
         definitions = c.get_node(".containers.definitions")
+        builds = c.get_node(".containers.builds")
+
+        if not definitions.exists() and not builds.exists():
+            return
+
+        # Index build labels by dockerfile path
+        build_labels_by_dockerfile = {}
+        if builds.exists():
+            for build in builds:
+                df = _normalize_path(
+                    build.get_value_or_default(".dockerfile", "Dockerfile")
+                ) or "Dockerfile"
+                labels = build.get_value_or_default(".labels", {})
+                if df not in build_labels_by_dockerfile:
+                    build_labels_by_dockerfile[df] = {}
+                build_labels_by_dockerfile[df].update(labels)
+
+        checked_dockerfiles = set()
+
+        # Check each Dockerfile definition with its matching build labels
         if definitions.exists():
             for definition in definitions:
                 if not definition.get_value_or_default(".valid", False):
                     continue
-                labels = definition.get_value_or_default(".labels", {})
-                dockerfile_labels.update(labels)
 
-        # Collect all labels from build commands
-        build_labels = {}
-        builds = c.get_node(".containers.builds")
-        if builds.exists():
-            for build in builds:
-                labels = build.get_value_or_default(".labels", {})
-                build_labels.update(labels)
+                path = _normalize_path(definition.get_value(".path"))
+                checked_dockerfiles.add(path)
 
-        # Union of both sources
-        all_labels = {**dockerfile_labels, **build_labels}
+                # Labels from this Dockerfile's LABEL instructions
+                def_labels = definition.get_value_or_default(".labels", {})
 
-        missing = [l for l in required if l not in all_labels]
+                # Labels from matching build commands
+                matching_build_labels = build_labels_by_dockerfile.get(path, {})
 
-        if missing:
-            c.fail(f"Missing required labels: {', '.join(missing)}")
+                # Union of both sources for this Dockerfile
+                all_labels = {**def_labels, **matching_build_labels}
+
+                missing = [l for l in required if l not in all_labels]
+                if missing:
+                    c.fail(
+                        f"'{path}' missing required labels: {', '.join(missing)}"
+                    )
+
+        # Check builds that don't match any Dockerfile definition
+        for df_path, labels in build_labels_by_dockerfile.items():
+            if df_path not in checked_dockerfiles:
+                missing = [l for l in required if l not in labels]
+                if missing:
+                    c.fail(
+                        f"Build for '{df_path}' missing required labels: "
+                        f"{', '.join(missing)}"
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Each Dockerfile definition is now checked independently against its matching build commands. A Dockerfile's LABEL instructions are unioned with labels from build commands that reference it (via `-f` flag).

This ensures every Dockerfile in the repo has the required labels, not just the component as a whole. Previously, labels from any Dockerfile or build satisfied the check globally — so a well-labeled main Dockerfile would mask an unlabeled secondary Dockerfile.

**Note:** This is strictly a policy logic change. The Component JSON schema, inputs, and check name are all unchanged — the policy reads the same `.containers.definitions[].labels` and `.containers.builds[].labels` paths.

*This fix was generated by AI.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container label validation now evaluates definitions and build configurations per Dockerfile, including builds without matching definitions.
  * Error messages are more precise, reporting the specific Dockerfile path and which required labels are missing.
  * Skips validation early when no definitions or builds are present to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->