### PR TITLE
fix: move runs_on from hook block to snippet level (ENG-444)

### DIFF
--- a/collectors/semgrep/lunar-collector.yml
+++ b/collectors/semgrep/lunar-collector.yml
@@ -24,9 +24,9 @@ collectors:
       check-runs API. Waits for scan completion and captures results.
       Categorizes as SAST (Code) or SCA (Supply Chain) based on check name.
     mainBash: github-app.sh
+    runs_on: [prs]
     hook:
       type: code
-      runs_on: [prs]
     keywords: ["semgrep", "github app", "sast", "code analysis"]
 
   - name: running-in-prs
@@ -36,9 +36,9 @@ collectors:
       that PR scanning is happening (since Semgrep GitHub App only posts checks
       on PRs, not directly on the default branch).
     mainBash: running-in-prs.sh
+    runs_on: [default-branch]
     hook:
       type: code
-      runs_on: [default-branch]
     keywords: ["semgrep", "pr scanning", "compliance proof", "default branch"]
 
   - name: cli

--- a/collectors/snyk/lunar-collector.yml
+++ b/collectors/snyk/lunar-collector.yml
@@ -28,9 +28,9 @@ collectors:
       commit status API. Waits for scan completion and captures results.
       Categorizes by scan type (Open Source, Code, Container, IaC).
     mainBash: github-app.sh
+    runs_on: [prs]
     hook:
       type: code
-      runs_on: [prs]
     keywords: ["snyk", "github app", "security scanning", "vulnerabilities"]
 
   - name: running-in-prs
@@ -40,9 +40,9 @@ collectors:
       that PR scanning is happening (since Snyk GitHub App only posts checks
       on PRs, not directly on the default branch).
     mainBash: running-in-prs.sh
+    runs_on: [default-branch]
     hook:
       type: code
-      runs_on: [default-branch]
     keywords: ["snyk", "pr scanning", "compliance proof", "default branch"]
 
   - name: cli


### PR DESCRIPTION
## Summary

The `runs_on` field was incorrectly placed **inside** the `hook:` block in both the snyk and semgrep collector YAMLs. The platform's `Hook` struct has no `RunsOn` field, so Go's `yaml.v3` silently dropped the value during parsing. This caused these collectors to get the default `runs_on: [prs, default-branch]` instead of their intended restriction.

**Impact:** `snyk.running-in-prs` and `semgrep.running-in-prs` (configured for `default-branch` only) were running on every PR. Similarly, `snyk.github-app` and `semgrep.github-app` (configured for `prs` only) were also running on the default branch.

## Changes

Moved `runs_on` from inside `hook:` to the snippet level (sibling of `hook:`) in:
- `collectors/snyk/lunar-collector.yml` — `github-app` and `running-in-prs`
- `collectors/semgrep/lunar-collector.yml` — `github-app` and `running-in-prs`

This matches the correct placement used by `collectors/jira` and `policies/ticket`, and aligns with the [platform docs](https://github.com/earthly/lunar/blob/main/docs/lunar-config/collectors.md#runs_on) updated in PR earthly/lunar#1006.

Fixes [ENG-444](https://linear.app/earthly-technologies/issue/ENG-444).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured configuration organization for Semgrep and Snyk collectors with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->