### PR TITLE
Update language plugin README selector examples

### DIFF
--- a/collectors/golang/README.md
+++ b/collectors/golang/README.md
@@ -44,7 +44,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 collectors:
   - uses: github://earthly/lunar-lib/collectors/golang@v1.0.0
-    on: [go]  # Or use domain: ["domain:your-domain"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     # include: [project, golangci-lint]  # Only include specific subcollectors
     # with:
     #   lint_timeout: "10m"

--- a/collectors/java/README.md
+++ b/collectors/java/README.md
@@ -42,6 +42,6 @@ Add to your `lunar-config.yml`:
 ```yaml
 collectors:
   - uses: github://earthly/lunar-lib/collectors/java@v1.0.0
-    on: [java]  # Or use domain: ["domain:your-domain"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     # include: [project, dependencies]  # Only include specific subcollectors
 ```

--- a/collectors/nodejs/README.md
+++ b/collectors/nodejs/README.md
@@ -38,6 +38,6 @@ Add to your `lunar-config.yml`:
 ```yaml
 collectors:
   - uses: github://earthly/lunar-lib/collectors/nodejs@v1.0.0
-    on: [nodejs]  # Or use domain: ["domain:your-domain"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     # include: [project, dependencies]  # Only include specific subcollectors
 ```

--- a/collectors/python/README.md
+++ b/collectors/python/README.md
@@ -39,6 +39,6 @@ Add to your `lunar-config.yml`:
 ```yaml
 collectors:
   - uses: github://earthly/lunar-lib/collectors/python@v1.0.0
-    on: [python]  # Or use domain: ["domain:your-domain"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     # include: [project, dependencies]  # Only include specific subcollectors
 ```

--- a/collectors/rust/README.md
+++ b/collectors/rust/README.md
@@ -55,7 +55,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 collectors:
   - uses: github://earthly/lunar-lib/collectors/rust@main
-    on: [rust]  # Or use domain: ["domain:your-domain"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     # include: [project, dependencies]  # Only include specific subcollectors
     # with:
     #   clippy_args: "-- -W clippy::pedantic"

--- a/policies/golang/README.md
+++ b/policies/golang/README.md
@@ -40,7 +40,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/golang@v1.0.0
-    on: [go]  # Or use tags like ["domain:backend"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: report-pr
     # include: [go-mod-exists, go-sum-exists]  # Only run specific checks
     with:

--- a/policies/java/README.md
+++ b/policies/java/README.md
@@ -39,7 +39,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/java@v1.0.0
-    on: [java]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: report-pr
     with:
       min_java_version: "17"

--- a/policies/linter/README.md
+++ b/policies/linter/README.md
@@ -33,7 +33,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
-    on: [go]  # Or use domain: ["domain:your-domain"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: report-pr
     with:
       language: "go"
@@ -45,7 +45,7 @@ policies:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/linter@v1.0.0
-    on: [go]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: block-pr
     with:
       language: "go"

--- a/policies/nodejs/README.md
+++ b/policies/nodejs/README.md
@@ -42,7 +42,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/nodejs@v1.0.0
-    on: [nodejs]  # Or use tags like ["domain:frontend"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: report-pr
     # include: [lockfile-exists, typescript-configured]  # Only run specific checks
     with:

--- a/policies/python/README.md
+++ b/policies/python/README.md
@@ -37,7 +37,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/python@v1.0.0
-    on: [python]  # Or use tags like ["domain:backend"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: report-pr
     # include: [lockfile-exists, linter-configured]  # Only run specific checks
     with:

--- a/policies/rust/README.md
+++ b/policies/rust/README.md
@@ -42,7 +42,7 @@ Add to your `lunar-config.yml`:
 ```yaml
 policies:
   - uses: github://earthly/lunar-lib/policies/rust@main
-    on: [rust]  # Or use tags like ["domain:backend"]
+    on: ["domain:your-domain"]  # replace with your own domain or tags
     enforcement: report-pr
     # include: [cargo-toml-exists, cargo-lock-exists]  # Only run specific checks
     with:


### PR DESCRIPTION
## Summary
- replace language-specific `on` examples in language plugin READMEs with the standard `on: [\"domain:your-domain\"]` placeholder
- add a short `replace with your own domain or tags` hint to those install snippets for collectors and policies
- keep the linter policy README consistent with the same selector example style

## Test plan
- [x] Verified the edited README snippets now use `on: [\"domain:your-domain\"]`
- [x] Confirmed the language plugin examples no longer use `on: [python]`, `on: [go]`, `on: [java]`, `on: [nodejs]`, or `on: [rust]`
- [x] Checked edited files for diagnostics with `ReadLints`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples to use domain-based selectors instead of language-specific identifiers. Users should now replace placeholder values with their actual domain or tags when configuring collectors and policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->