### PR TITLE
sbom: accept JSON array strings for disallowed_licenses and disallowed_packages

### DIFF
--- a/policies/sbom/README.md
+++ b/policies/sbom/README.md
@@ -49,7 +49,10 @@ policies:
       min_license_coverage: "90"
       min_components: "1"
       # allowed_formats: "cyclonedx"
+      # disallowed_packages: '["alibabacloud", "aliyun-.*", ".*\\.ru$"]'
 ```
+
+> **Tip:** `disallowed_licenses` and `disallowed_packages` accept either a comma-separated string (`"GPL.*,AGPL.*"`) or a JSON array string (`'["GPL.*", "AGPL.*"]'`). JSON arrays are recommended when patterns contain commas or complex regex.
 
 ## Examples
 

--- a/policies/sbom/disallowed-licenses.py
+++ b/policies/sbom/disallowed-licenses.py
@@ -1,12 +1,12 @@
 import re
 import sys
 sys.path.insert(0, ".")
-from helpers import get_sbom_components
+from helpers import get_sbom_components, parse_patterns
 from lunar_policy import Check, variable_or_default
 
 with Check("disallowed-licenses", "Checks for disallowed licenses in SBOM components") as c:
     disallowed_str = variable_or_default("disallowed_licenses", "")
-    disallowed_patterns = [p.strip() for p in disallowed_str.split(",") if p.strip()]
+    disallowed_patterns = parse_patterns(disallowed_str)
 
     if not disallowed_patterns:
         # No patterns configured — auto-pass

--- a/policies/sbom/disallowed-packages.py
+++ b/policies/sbom/disallowed-packages.py
@@ -2,7 +2,7 @@ import re
 import sys
 
 sys.path.insert(0, ".")
-from helpers import get_sbom_components
+from helpers import get_sbom_components, parse_patterns
 from lunar_policy import Check, variable_or_default
 
 
@@ -14,7 +14,7 @@ def check_disallowed_packages(node=None):
     )
     with c:
         patterns_str = variable_or_default("disallowed_packages", "")
-        patterns = [p.strip() for p in patterns_str.split(",") if p.strip()]
+        patterns = parse_patterns(patterns_str)
 
         if not patterns:
             pass  # No patterns configured — auto-pass

--- a/policies/sbom/helpers.py
+++ b/policies/sbom/helpers.py
@@ -1,5 +1,24 @@
 """Shared helpers for SBOM policy checks."""
 
+import json
+
+
+def parse_patterns(raw):
+    """Parse a pattern list from a comma-separated string or JSON array string.
+
+    Accepts either ``"GPL.*,AGPL.*"`` or ``'["GPL.*", "AGPL.*"]'``.
+    Returns a list of stripped, non-empty strings.
+    """
+    raw = raw.strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        try:
+            return [p.strip() for p in json.loads(raw) if isinstance(p, str) and p.strip()]
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON array in pattern input: {e}")
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
 
 def get_sbom_components(c):
     """Collect SBOM components from both auto and cicd paths.

--- a/policies/sbom/lunar-policy.yml
+++ b/policies/sbom/lunar-policy.yml
@@ -77,7 +77,7 @@ policies:
 
 inputs:
   disallowed_licenses:
-    description: Comma-separated regex patterns of disallowed licenses (e.g. "GPL.*,AGPL.*")
+    description: Regex patterns of disallowed licenses. Accepts a comma-separated string (e.g. "GPL.*,AGPL.*") or a JSON array (e.g. '["GPL.*", "AGPL.*"]').
   min_license_coverage:
     description: Minimum percentage of components that must have license info (0-100)
     default: "50"
@@ -91,5 +91,5 @@ inputs:
     description: Comma-separated list of blocked countries for license origin checks (e.g. "Russia,China,Iran,North Korea")
     default: ""
   disallowed_packages:
-    description: Comma-separated regex patterns for disallowed packages (matched against PURL, name, and group; e.g. "ru\\.yandex\\..*,com\\.alibaba\\..*")
+    description: Regex patterns for disallowed packages, matched against PURL, name, and group. Accepts a comma-separated string or a JSON array (e.g. '["ru\\.yandex\\..*", "com\\.alibaba\\..*"]').
     default: ""


### PR DESCRIPTION
## Summary

- `disallowed_licenses` and `disallowed_packages` inputs now accept either a comma-separated string or a JSON array string
- JSON arrays are cleaner when patterns contain commas or complex regex (e.g. supply-chain blocklists with multiple alternations)
- Fully backward compatible — existing comma-separated configs continue to work unchanged

### Before

```yaml
with:
  disallowed_packages: "(^|/)(alibabacloud|alibaba-cloud-sdk-rust|aliyun[-a-z0-9_]*)($|@),(^|/)[a-z0-9_.-]*\\.ru($|@)"
```

### After

```yaml
with:
  disallowed_packages: |-
    [
      "(^|/)(alibabacloud|alibaba-cloud-sdk-rust|aliyun[-a-z0-9_]*)($|@)",
      "(^|/)[a-z0-9_.-]*\\.ru($|@)"
    ]
```

## Changes

- **`disallowed-packages.py`** — added `_parse_patterns()` helper that detects `[` prefix and uses `json.loads()`, otherwise falls back to comma split
- **`disallowed-licenses.py`** — same `_parse_patterns()` helper added for consistency
- **`lunar-policy.yml`** — input descriptions updated to document both formats
- **`README.md`** — installation example updated with JSON array form and a tip explaining both options

## Test plan

- [x] Verify `disallowed_packages` with comma-separated string still works (backward compat)
- [x] Verify `disallowed_packages` with JSON array string catches matching packages
- [x] Verify `disallowed_licenses` with JSON array string catches matching licenses
- [x] Verify empty string input still auto-passes
- [x] Verify malformed JSON raises a clear error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified SBOM policy input docs and added examples showing comma-separated and JSON array formats; added a tip recommending JSON arrays for complex patterns.

* **New Features**
  * `disallowed_licenses` and `disallowed_packages` now accept either comma-separated strings or JSON array strings.

* **Bug Fixes / Validation**
  * Improved parsing/validation of pattern inputs with clearer errors for invalid JSON array inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->