### PR TITLE
Skip language policies when only CI data exists (no code collector)

### DIFF
--- a/collectors/golang/project.sh
+++ b/collectors/golang/project.sh
@@ -41,6 +41,7 @@ jq -n \
     --argjson vendor_exists "$vendor_exists" \
     --argjson goreleaser_exists "$goreleaser_exists" \
     '{
+        project_exists: $go_mod_exists,
         build_systems: ["go"],
         go_mod_exists: $go_mod_exists,
         go_sum_exists: $go_sum_exists,

--- a/collectors/java/project.sh
+++ b/collectors/java/project.sh
@@ -34,6 +34,9 @@ if [[ -f "gradle.lockfile" ]]; then
     gradle_lock_exists=true
 fi
 
+project_exists=false
+[[ "$pom_exists" == true ]] || [[ "$gradle_exists" == true ]] && project_exists=true
+
 # Detect static analysis tools
 if [[ -f "checkstyle.xml" ]] || [[ -f "config/checkstyle/checkstyle.xml" ]]; then
     checkstyle_configured=true
@@ -100,7 +103,9 @@ jq -n \
     --argjson gradle_lock_exists "$gradle_lock_exists" \
     --argjson checkstyle_configured "$checkstyle_configured" \
     --argjson spotbugs_configured "$spotbugs_configured" \
+    --argjson project_exists "$project_exists" \
     '{
+        project_exists: $project_exists,
         build_systems: $build_systems,
         pom_xml_exists: $pom_exists,
         build_gradle_exists: $gradle_exists,

--- a/collectors/nodejs/project.sh
+++ b/collectors/nodejs/project.sh
@@ -98,6 +98,7 @@ jq -n \
     --arg engines_node "$engines_node" \
     --arg monorepo_type "$monorepo_type" \
     '{
+        project_exists: $package_json_exists,
         build_systems: $build_systems,
         package_json_exists: $package_json_exists,
         package_lock_exists: $package_lock_exists,

--- a/collectors/php/project.sh
+++ b/collectors/php/project.sh
@@ -86,6 +86,7 @@ jq -n \
     --argjson composer_lock_exists "$composer_lock_exists" \
     --argjson vendor_exists "$vendor_exists" \
     '{
+        project_exists: $composer_json_exists,
         build_systems: ["composer"],
         phpunit_configured: $phpunit_configured,
         static_analysis_configured: $static_analysis_configured,

--- a/collectors/python/project.sh
+++ b/collectors/python/project.sh
@@ -16,18 +16,20 @@ setup_py_exists=false
 pipfile_exists=false
 poetry_lock_exists=false
 pipfile_lock_exists=false
+setup_cfg_exists=false
 python_version_file_exists=false
 
 [[ -f "pyproject.toml" ]] && pyproject_exists=true
 [[ -f "requirements.txt" ]] && requirements_txt_exists=true
 [[ -f "setup.py" ]] && setup_py_exists=true
+[[ -f "setup.cfg" ]] && setup_cfg_exists=true
 [[ -f "Pipfile" ]] && pipfile_exists=true
 [[ -f "poetry.lock" ]] && poetry_lock_exists=true
 [[ -f "Pipfile.lock" ]] && pipfile_lock_exists=true
 [[ -f ".python-version" ]] && python_version_file_exists=true
 
 project_exists=false
-[[ "$pyproject_exists" == true ]] || [[ "$requirements_txt_exists" == true ]] || [[ "$setup_py_exists" == true ]] || [[ "$pipfile_exists" == true ]] && project_exists=true
+[[ "$pyproject_exists" == true ]] || [[ "$requirements_txt_exists" == true ]] || [[ "$setup_py_exists" == true ]] || [[ "$setup_cfg_exists" == true ]] || [[ "$pipfile_exists" == true ]] && project_exists=true
 
 # Detect build systems
 build_systems=()

--- a/collectors/python/project.sh
+++ b/collectors/python/project.sh
@@ -26,6 +26,9 @@ python_version_file_exists=false
 [[ -f "Pipfile.lock" ]] && pipfile_lock_exists=true
 [[ -f ".python-version" ]] && python_version_file_exists=true
 
+project_exists=false
+[[ "$pyproject_exists" == true ]] || [[ "$requirements_txt_exists" == true ]] || [[ "$setup_py_exists" == true ]] || [[ "$pipfile_exists" == true ]] && project_exists=true
+
 # Detect build systems
 build_systems=()
 if [[ "$pyproject_exists" == true ]]; then
@@ -105,7 +108,9 @@ jq -n \
     --arg linter "$linter" \
     --argjson type_checker_configured "$type_checker_configured" \
     --arg type_checker "$type_checker" \
+    --argjson project_exists "$project_exists" \
     '{
+        project_exists: $project_exists,
         build_systems: $build_systems,
         pyproject_exists: $pyproject_exists,
         requirements_txt_exists: $requirements_txt_exists,

--- a/collectors/rust/project.sh
+++ b/collectors/rust/project.sh
@@ -100,6 +100,7 @@ jq -n \
     --argjson workspace "$workspace_json" \
     --argjson unsafe_blocks "$unsafe_json" \
     '{
+        project_exists: $cargo_toml_exists,
         build_systems: ["cargo"],
         cargo_toml_exists: $cargo_toml_exists,
         cargo_lock_exists: $cargo_lock_exists,

--- a/policies/java/min_gradle_version.py
+++ b/policies/java/min_gradle_version.py
@@ -30,7 +30,8 @@ def check_min_gradle_version(min_version=None, node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
-        if not java.get_node(".project_exists").exists():
+        project_exists_node = java.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Java project detected in this component")
 
         cmds_node = java.get_node(".cicd.cmds")

--- a/policies/java/min_gradle_version.py
+++ b/policies/java/min_gradle_version.py
@@ -30,6 +30,8 @@ def check_min_gradle_version(min_version=None, node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
+        if not java.get_node(".project_exists").exists():
+            c.skip("No Java project detected in this component")
 
         cmds_node = java.get_node(".cicd.cmds")
         if not cmds_node.exists():

--- a/policies/java/min_java_version.py
+++ b/policies/java/min_java_version.py
@@ -29,6 +29,8 @@ def check_min_java_version(min_version=None, node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
+        if not java.get_node(".project_exists").exists():
+            c.skip("No Java project detected in this component")
 
         version_node = java.get_node(".version")
         if not version_node.exists():

--- a/policies/java/min_java_version.py
+++ b/policies/java/min_java_version.py
@@ -29,7 +29,8 @@ def check_min_java_version(min_version=None, node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
-        if not java.get_node(".project_exists").exists():
+        project_exists_node = java.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Java project detected in this component")
 
         version_node = java.get_node(".version")

--- a/policies/java/min_maven_version.py
+++ b/policies/java/min_maven_version.py
@@ -30,7 +30,8 @@ def check_min_maven_version(min_version=None, node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
-        if not java.get_node(".project_exists").exists():
+        project_exists_node = java.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Java project detected in this component")
 
         cmds_node = java.get_node(".cicd.cmds")

--- a/policies/java/min_maven_version.py
+++ b/policies/java/min_maven_version.py
@@ -30,6 +30,8 @@ def check_min_maven_version(min_version=None, node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
+        if not java.get_node(".project_exists").exists():
+            c.skip("No Java project detected in this component")
 
         cmds_node = java.get_node(".cicd.cmds")
         if not cmds_node.exists():

--- a/policies/java/tests_all_modules.py
+++ b/policies/java/tests_all_modules.py
@@ -8,7 +8,8 @@ def check_tests_all_modules(node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
-        if not java.get_node(".project_exists").exists():
+        project_exists_node = java.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Java project detected in this component")
 
         scope_node = java.get_node(".tests.scope")

--- a/policies/java/tests_all_modules.py
+++ b/policies/java/tests_all_modules.py
@@ -8,6 +8,8 @@ def check_tests_all_modules(node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
+        if not java.get_node(".project_exists").exists():
+            c.skip("No Java project detected in this component")
 
         scope_node = java.get_node(".tests.scope")
         if not scope_node.exists():

--- a/policies/java/wrapper_exists.py
+++ b/policies/java/wrapper_exists.py
@@ -8,7 +8,8 @@ def check_wrapper_exists(node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
-        if not java.get_node(".project_exists").exists():
+        project_exists_node = java.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Java project detected in this component")
 
         build_systems_node = java.get_node(".build_systems")

--- a/policies/java/wrapper_exists.py
+++ b/policies/java/wrapper_exists.py
@@ -8,6 +8,8 @@ def check_wrapper_exists(node=None):
         java = c.get_node(".lang.java")
         if not java.exists():
             c.skip("Not a Java project")
+        if not java.get_node(".project_exists").exists():
+            c.skip("No Java project detected in this component")
 
         build_systems_node = java.get_node(".build_systems")
         if not build_systems_node.exists():

--- a/policies/nodejs/checks/engines_pinned.py
+++ b/policies/nodejs/checks/engines_pinned.py
@@ -8,7 +8,8 @@ def check_engines_pinned(node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
-        if not nodejs.get_node(".project_exists").exists():
+        project_exists_node = nodejs.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Node.js project detected in this component")
 
         engines_node = nodejs.get_node(".engines_node")

--- a/policies/nodejs/checks/engines_pinned.py
+++ b/policies/nodejs/checks/engines_pinned.py
@@ -8,6 +8,8 @@ def check_engines_pinned(node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
+        if not nodejs.get_node(".project_exists").exists():
+            c.skip("No Node.js project detected in this component")
 
         engines_node = nodejs.get_node(".engines_node")
         if not engines_node.exists():

--- a/policies/nodejs/checks/lockfile_exists.py
+++ b/policies/nodejs/checks/lockfile_exists.py
@@ -8,6 +8,8 @@ def check_lockfile_exists(node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
+        if not nodejs.get_node(".project_exists").exists():
+            c.skip("No Node.js project detected in this component")
 
         package_lock = nodejs.get_value_or_default(".package_lock_exists", False)
         yarn_lock = nodejs.get_value_or_default(".yarn_lock_exists", False)

--- a/policies/nodejs/checks/lockfile_exists.py
+++ b/policies/nodejs/checks/lockfile_exists.py
@@ -8,7 +8,8 @@ def check_lockfile_exists(node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
-        if not nodejs.get_node(".project_exists").exists():
+        project_exists_node = nodejs.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Node.js project detected in this component")
 
         package_lock = nodejs.get_value_or_default(".package_lock_exists", False)

--- a/policies/nodejs/checks/min_node_version.py
+++ b/policies/nodejs/checks/min_node_version.py
@@ -18,7 +18,8 @@ def check_min_node_version(min_version=None, node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
-        if not nodejs.get_node(".project_exists").exists():
+        project_exists_node = nodejs.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Node.js project detected in this component")
 
         version_node = nodejs.get_node(".version")

--- a/policies/nodejs/checks/min_node_version.py
+++ b/policies/nodejs/checks/min_node_version.py
@@ -18,6 +18,8 @@ def check_min_node_version(min_version=None, node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
+        if not nodejs.get_node(".project_exists").exists():
+            c.skip("No Node.js project detected in this component")
 
         version_node = nodejs.get_node(".version")
         if not version_node.exists():

--- a/policies/nodejs/checks/min_node_version_cicd.py
+++ b/policies/nodejs/checks/min_node_version_cicd.py
@@ -18,6 +18,8 @@ def check_min_node_version_cicd(min_version=None, node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
+        if not nodejs.get_node(".project_exists").exists() and not nodejs.get_node(".cicd").exists():
+            c.skip("No Node.js project detected in this component")
 
         cmds_node = nodejs.get_node(".cicd.cmds")
         if not cmds_node.exists():

--- a/policies/nodejs/checks/min_node_version_cicd.py
+++ b/policies/nodejs/checks/min_node_version_cicd.py
@@ -18,7 +18,8 @@ def check_min_node_version_cicd(min_version=None, node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
-        if not nodejs.get_node(".project_exists").exists() and not nodejs.get_node(".cicd").exists():
+        project_exists_node = nodejs.get_node(".project_exists")
+        if (not project_exists_node.exists() or not project_exists_node.get_value()) and not nodejs.get_node(".cicd").exists():
             c.skip("No Node.js project detected in this component")
 
         cmds_node = nodejs.get_node(".cicd.cmds")

--- a/policies/nodejs/checks/min_node_version_cicd.py
+++ b/policies/nodejs/checks/min_node_version_cicd.py
@@ -19,7 +19,7 @@ def check_min_node_version_cicd(min_version=None, node=None):
         if not nodejs.exists():
             c.skip("Not a Node.js project")
         project_exists_node = nodejs.get_node(".project_exists")
-        if (not project_exists_node.exists() or not project_exists_node.get_value()) and not nodejs.get_node(".cicd").exists():
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Node.js project detected in this component")
 
         cmds_node = nodejs.get_node(".cicd.cmds")

--- a/policies/nodejs/checks/typescript_configured.py
+++ b/policies/nodejs/checks/typescript_configured.py
@@ -8,6 +8,8 @@ def check_typescript_configured(node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
+        if not nodejs.get_node(".project_exists").exists():
+            c.skip("No Node.js project detected in this component")
 
         tsconfig = nodejs.get_node(".tsconfig_exists")
         if not tsconfig.exists():

--- a/policies/nodejs/checks/typescript_configured.py
+++ b/policies/nodejs/checks/typescript_configured.py
@@ -8,7 +8,8 @@ def check_typescript_configured(node=None):
         nodejs = c.get_node(".lang.nodejs")
         if not nodejs.exists():
             c.skip("Not a Node.js project")
-        if not nodejs.get_node(".project_exists").exists():
+        project_exists_node = nodejs.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Node.js project detected in this component")
 
         tsconfig = nodejs.get_node(".tsconfig_exists")

--- a/policies/php/code_style_configured.py
+++ b/policies/php/code_style_configured.py
@@ -8,6 +8,8 @@ def check_code_style_configured(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists():
+            c.skip("No PHP project detected in this component")
 
         cs_node = php.get_node(".code_style_configured")
         if not cs_node.exists():

--- a/policies/php/code_style_configured.py
+++ b/policies/php/code_style_configured.py
@@ -8,7 +8,8 @@ def check_code_style_configured(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         cs_node = php.get_node(".code_style_configured")

--- a/policies/php/composer_json_exists.py
+++ b/policies/php/composer_json_exists.py
@@ -8,8 +8,6 @@ def check_composer_json_exists(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists():
-            c.skip("No PHP project detected in this component")
 
         composer = php.get_node(".composer")
         if not composer.exists():

--- a/policies/php/composer_json_exists.py
+++ b/policies/php/composer_json_exists.py
@@ -8,6 +8,8 @@ def check_composer_json_exists(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists():
+            c.skip("No PHP project detected in this component")
 
         composer = php.get_node(".composer")
         if not composer.exists():

--- a/policies/php/composer_lock_exists.py
+++ b/policies/php/composer_lock_exists.py
@@ -8,7 +8,8 @@ def check_composer_lock_exists(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         composer = php.get_node(".composer")

--- a/policies/php/composer_lock_exists.py
+++ b/policies/php/composer_lock_exists.py
@@ -8,6 +8,8 @@ def check_composer_lock_exists(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists():
+            c.skip("No PHP project detected in this component")
 
         composer = php.get_node(".composer")
         if not composer.exists():

--- a/policies/php/min_composer_version.py
+++ b/policies/php/min_composer_version.py
@@ -11,6 +11,8 @@ def check_min_composer_version(min_version=None, node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists() and not php.get_node(".cicd").exists():
+            c.skip("No PHP project detected in this component")
 
         cmds_node = php.get_node(".composer.cicd.cmds")
         if not cmds_node.exists():

--- a/policies/php/min_composer_version.py
+++ b/policies/php/min_composer_version.py
@@ -12,7 +12,7 @@ def check_min_composer_version(min_version=None, node=None):
         if not php.exists():
             c.skip("Not a PHP project")
         project_exists_node = php.get_node(".project_exists")
-        if (not project_exists_node.exists() or not project_exists_node.get_value()) and not php.get_node(".cicd").exists():
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         cmds_node = php.get_node(".composer.cicd.cmds")

--- a/policies/php/min_composer_version.py
+++ b/policies/php/min_composer_version.py
@@ -11,7 +11,8 @@ def check_min_composer_version(min_version=None, node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists() and not php.get_node(".cicd").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if (not project_exists_node.exists() or not project_exists_node.get_value()) and not php.get_node(".cicd").exists():
             c.skip("No PHP project detected in this component")
 
         cmds_node = php.get_node(".composer.cicd.cmds")

--- a/policies/php/min_version.py
+++ b/policies/php/min_version.py
@@ -13,6 +13,8 @@ def check_min_version(min_version=None, node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists():
+            c.skip("No PHP project detected in this component")
 
         version_node = php.get_node(".version")
         if not version_node.exists():

--- a/policies/php/min_version.py
+++ b/policies/php/min_version.py
@@ -13,7 +13,8 @@ def check_min_version(min_version=None, node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         version_node = php.get_node(".version")

--- a/policies/php/min_version_cicd.py
+++ b/policies/php/min_version_cicd.py
@@ -11,6 +11,8 @@ def check_min_version_cicd(min_version=None, node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists() and not php.get_node(".cicd").exists():
+            c.skip("No PHP project detected in this component")
 
         cmds_node = php.get_node(".cicd.cmds")
         if not cmds_node.exists():

--- a/policies/php/min_version_cicd.py
+++ b/policies/php/min_version_cicd.py
@@ -11,7 +11,8 @@ def check_min_version_cicd(min_version=None, node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists() and not php.get_node(".cicd").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if (not project_exists_node.exists() or not project_exists_node.get_value()) and not php.get_node(".cicd").exists():
             c.skip("No PHP project detected in this component")
 
         cmds_node = php.get_node(".cicd.cmds")

--- a/policies/php/min_version_cicd.py
+++ b/policies/php/min_version_cicd.py
@@ -12,7 +12,7 @@ def check_min_version_cicd(min_version=None, node=None):
         if not php.exists():
             c.skip("Not a PHP project")
         project_exists_node = php.get_node(".project_exists")
-        if (not project_exists_node.exists() or not project_exists_node.get_value()) and not php.get_node(".cicd").exists():
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         cmds_node = php.get_node(".cicd.cmds")

--- a/policies/php/phpunit_configured.py
+++ b/policies/php/phpunit_configured.py
@@ -8,6 +8,8 @@ def check_phpunit_configured(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists():
+            c.skip("No PHP project detected in this component")
 
         phpunit_node = php.get_node(".phpunit_configured")
         if not phpunit_node.exists():

--- a/policies/php/phpunit_configured.py
+++ b/policies/php/phpunit_configured.py
@@ -8,7 +8,8 @@ def check_phpunit_configured(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         phpunit_node = php.get_node(".phpunit_configured")

--- a/policies/php/static_analysis_configured.py
+++ b/policies/php/static_analysis_configured.py
@@ -8,7 +8,8 @@ def check_static_analysis_configured(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
-        if not php.get_node(".project_exists").exists():
+        project_exists_node = php.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No PHP project detected in this component")
 
         sa_node = php.get_node(".static_analysis_configured")

--- a/policies/php/static_analysis_configured.py
+++ b/policies/php/static_analysis_configured.py
@@ -8,6 +8,8 @@ def check_static_analysis_configured(node=None):
         php = c.get_node(".lang.php")
         if not php.exists():
             c.skip("Not a PHP project")
+        if not php.get_node(".project_exists").exists():
+            c.skip("No PHP project detected in this component")
 
         sa_node = php.get_node(".static_analysis_configured")
         if not sa_node.exists():

--- a/policies/python/linter_configured.py
+++ b/policies/python/linter_configured.py
@@ -8,6 +8,8 @@ def check_linter_configured(node=None):
         python = c.get_node(".lang.python")
         if not python.exists():
             c.skip("Not a Python project")
+        if not python.get_node(".project_exists").exists():
+            c.skip("No Python project detected in this component")
 
         linter_node = python.get_node(".linter_configured")
         if not linter_node.exists():

--- a/policies/python/linter_configured.py
+++ b/policies/python/linter_configured.py
@@ -8,7 +8,8 @@ def check_linter_configured(node=None):
         python = c.get_node(".lang.python")
         if not python.exists():
             c.skip("Not a Python project")
-        if not python.get_node(".project_exists").exists():
+        project_exists_node = python.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Python project detected in this component")
 
         linter_node = python.get_node(".linter_configured")

--- a/policies/python/lockfile_exists.py
+++ b/policies/python/lockfile_exists.py
@@ -8,6 +8,8 @@ def check_lockfile_exists(node=None):
         python = c.get_node(".lang.python")
         if not python.exists():
             c.skip("Not a Python project")
+        if not python.get_node(".project_exists").exists():
+            c.skip("No Python project detected in this component")
 
         # Check for poetry.lock
         poetry_lock = python.get_node(".poetry_lock_exists")

--- a/policies/python/lockfile_exists.py
+++ b/policies/python/lockfile_exists.py
@@ -8,7 +8,8 @@ def check_lockfile_exists(node=None):
         python = c.get_node(".lang.python")
         if not python.exists():
             c.skip("Not a Python project")
-        if not python.get_node(".project_exists").exists():
+        project_exists_node = python.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Python project detected in this component")
 
         # Check for poetry.lock

--- a/policies/python/min_python_version.py
+++ b/policies/python/min_python_version.py
@@ -11,7 +11,8 @@ def check_min_python_version(min_version=None, node=None):
         python = c.get_node(".lang.python")
         if not python.exists():
             c.skip("Not a Python project")
-        if not python.get_node(".project_exists").exists():
+        project_exists_node = python.get_node(".project_exists")
+        if not project_exists_node.exists() or not project_exists_node.get_value():
             c.skip("No Python project detected in this component")
 
         version_node = python.get_node(".version")

--- a/policies/python/min_python_version.py
+++ b/policies/python/min_python_version.py
@@ -11,6 +11,8 @@ def check_min_python_version(min_version=None, node=None):
         python = c.get_node(".lang.python")
         if not python.exists():
             c.skip("Not a Python project")
+        if not python.get_node(".project_exists").exists():
+            c.skip("No Python project detected in this component")
 
         version_node = python.get_node(".version")
         if not version_node.exists():


### PR DESCRIPTION
## Summary

Language-specific policies (Python, Java, Node.js, PHP) gate on `.lang.<language>` existing in the component JSON. But CI collectors can create that node incidentally — for example, `pip install semgrep` on a Go repo creates `.lang.python.cicd` data. This causes all Python policies to evaluate against a Go component, producing `no-data` / stale results.

## Changes

**Collectors (6 files):** Each language code collector's `project.sh` now writes `project_exists: true` when a project manifest is detected. The value is derived from existing variables (e.g., `go_mod_exists`, `pom_exists`, `package_json_exists`) — no duplicate file checks.

| Language | `project_exists` derived from |
|----------|-------------------------------|
| Go | `go_mod_exists` |
| Java | `pom_exists \|\| gradle_exists` |
| Node.js | `package_json_exists` |
| Python | `pyproject_exists \|\| requirements_txt_exists \|\| setup_py_exists \|\| pipfile_exists` |
| PHP | `composer_json_exists` |
| Rust | `cargo_toml_exists` |

**Policies (21 files):** Check `.lang.<language>.project_exists` and skip when absent. This ensures language policies only evaluate against components that actually have a project manifest for that language.

| Language | Checks updated |
|----------|---------------|
| Python | 3 (lockfile_exists, linter_configured, min_python_version) |
| Java | 5 (all checks) |
| Node.js | 5 (all checks) |
| PHP | 8 (all checks) |

## Context

Discovered on `pantalasa-cronos/backend` (a Go repo) where `pip install semgrep` in CI created `.lang.python.cicd`, causing all Python policy checks to return `no-data` instead of `skipped`. Same pattern affects Java, Node.js, and PHP policies when CI tools incidentally create language nodes.

## Testing

Tested with `lunar collector dev` and `lunar policy dev` on cronos components:

| Test | Component | Result |
|------|-----------|--------|
| Python collector on auth (Python) | `project_exists: true` | ✅ |
| Python collector on backend (Go) | No data written | ✅ |
| Java collector on hadoop (Java) | `project_exists: true` | ✅ |
| Node.js collector on frontend (Node) | `project_exists: true` | ✅ |
| Python linter policy on backend (CI-only) | **Skipped** | ✅ |
| Python linter policy on auth (real project) | **Failed** (no linter) | ✅ |
| Java version policy on backend (no Java) | **Skipped** | ✅ |
| Java version policy with CI-only data | **Skipped** | ✅ |
| Node.js lockfile policy on backend (no Node) | **Skipped** | ✅ |
| PHP composer policy on backend (no PHP) | **Skipped** | ✅ |

Cronos config is currently pointing at this branch for live testing across multiple components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit a unified "project detected" marker for multiple language scanners so components clearly indicate whether a real project exists.

* **Bug Fixes**
  * Many language-specific checks now skip when no project is detected, reducing false positive policy failures and improving accuracy of requirement/version/lockfile validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->