### PR TITLE
Bump lunar-policy to 0.2.3 in all policies

### DIFF
--- a/policies/ai-use/requirements.txt
+++ b/policies/ai-use/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/codeowners/requirements.txt
+++ b/policies/codeowners/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/compliance-docs/requirements.txt
+++ b/policies/compliance-docs/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/container-scan/requirements.txt
+++ b/policies/container-scan/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/container/requirements.txt
+++ b/policies/container/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/dependencies/requirements.txt
+++ b/policies/dependencies/requirements.txt
@@ -1,2 +1,2 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3
 semver==3.0.2

--- a/policies/feature-flags/requirements.txt
+++ b/policies/feature-flags/requirements.txt
@@ -1,2 +1,2 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3
 

--- a/policies/golang/requirements.txt
+++ b/policies/golang/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/iac-scan/requirements.txt
+++ b/policies/iac-scan/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/iac/requirements.txt
+++ b/policies/iac/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/java/requirements.txt
+++ b/policies/java/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/k8s/requirements.txt
+++ b/policies/k8s/requirements.txt
@@ -1,2 +1,2 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3
 

--- a/policies/linter/requirements.txt
+++ b/policies/linter/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/nodejs/requirements.txt
+++ b/policies/nodejs/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/php/requirements.txt
+++ b/policies/php/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/python/requirements.txt
+++ b/policies/python/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/readme/requirements.txt
+++ b/policies/readme/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/rust/requirements.txt
+++ b/policies/rust/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/sast/requirements.txt
+++ b/policies/sast/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/sbom/requirements.txt
+++ b/policies/sbom/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/sca/requirements.txt
+++ b/policies/sca/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/terraform/requirements.txt
+++ b/policies/terraform/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/testing/requirements.txt
+++ b/policies/testing/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/ticket/requirements.txt
+++ b/policies/ticket/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3

--- a/policies/vcs/requirements.txt
+++ b/policies/vcs/requirements.txt
@@ -1,1 +1,1 @@
-lunar-policy==0.2.2
+lunar-policy==0.2.3


### PR DESCRIPTION
## What
Pins `lunar-policy` to **0.2.3** in every policy plugin `requirements.txt` (was 0.2.2).

## Why
Align built-in policies with the latest `lunar-policy` release so CI and local runs use consistent SDK behavior.

## How
Mechanical version bump across all `policies/*/requirements.txt` files.

🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions across multiple policy modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->