### PR TITLE
codeowners: guard all policies with .exists() before accessing component JSON

### DIFF
--- a/policies/codeowners/catchall.py
+++ b/policies/codeowners/catchall.py
@@ -4,12 +4,17 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("catchall", "CODEOWNERS should have a default catch-all rule", node=node)
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
         has_catchall = False
-        for rule in c.get_node(".ownership.codeowners.rules"):
+        for rule in codeowners.get_node(".rules"):
             if rule.get_value(".pattern") == "*":
                 has_catchall = True
                 break

--- a/policies/codeowners/exists.py
+++ b/policies/codeowners/exists.py
@@ -4,8 +4,13 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("exists", "Repository should have a CODEOWNERS file", node=node)
     with c:
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
         c.assert_true(
-            c.get_value(".ownership.codeowners.exists"),
+            codeowners.get_value(".exists"),
             "No CODEOWNERS file found. Add a CODEOWNERS file to the repository root, .github/, or docs/ directory.",
         )
     return c

--- a/policies/codeowners/max_owners.py
+++ b/policies/codeowners/max_owners.py
@@ -8,7 +8,12 @@ def main(node=None, max_owners_override=None):
         node=node,
     )
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
@@ -24,7 +29,7 @@ def main(node=None, max_owners_override=None):
                 f"Policy misconfiguration: max_owners_per_rule must be a number, got: {max_owners}"
             )
 
-        for rule in c.get_node(".ownership.codeowners.rules"):
+        for rule in codeowners.get_node(".rules"):
             pattern = rule.get_value(".pattern")
             owner_count = rule.get_value(".owner_count")
             c.assert_less_or_equal(

--- a/policies/codeowners/min_owners.py
+++ b/policies/codeowners/min_owners.py
@@ -8,7 +8,12 @@ def main(node=None, min_owners_override=None):
         node=node,
     )
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
@@ -24,7 +29,7 @@ def main(node=None, min_owners_override=None):
                 f"Policy misconfiguration: min_owners_per_rule must be a number, got: {min_owners}"
             )
 
-        for rule in c.get_node(".ownership.codeowners.rules"):
+        for rule in codeowners.get_node(".rules"):
             pattern = rule.get_value(".pattern")
             owner_count = rule.get_value(".owner_count")
             # Skip rules that intentionally un-assign ownership (0 owners)

--- a/policies/codeowners/no_empty_rules.py
+++ b/policies/codeowners/no_empty_rules.py
@@ -8,11 +8,16 @@ def main(node=None):
         node=node,
     )
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
-        for rule in c.get_node(".ownership.codeowners.rules"):
+        for rule in codeowners.get_node(".rules"):
             pattern = rule.get_value(".pattern")
             owner_count = rule.get_value(".owner_count")
             c.assert_true(

--- a/policies/codeowners/no_individuals_only.py
+++ b/policies/codeowners/no_individuals_only.py
@@ -8,13 +8,18 @@ def main(node=None):
         node=node,
     )
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
-        team_owners = set(c.get_value(".ownership.codeowners.team_owners"))
+        team_owners = set(codeowners.get_value(".team_owners"))
 
-        for rule in c.get_node(".ownership.codeowners.rules"):
+        for rule in codeowners.get_node(".rules"):
             owners = rule.get_value_or_default(".owners", [])
             if not owners:
                 continue  # Empty rules handled by no-empty-rules check

--- a/policies/codeowners/team_owners.py
+++ b/policies/codeowners/team_owners.py
@@ -8,11 +8,16 @@ def main(node=None):
         node=node,
     )
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
-        team_owners = c.get_value(".ownership.codeowners.team_owners")
+        team_owners = codeowners.get_value(".team_owners")
         c.assert_true(
             len(team_owners) > 0,
             "CODEOWNERS has no team-based owners (@org/team). "

--- a/policies/codeowners/valid.py
+++ b/policies/codeowners/valid.py
@@ -4,15 +4,20 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("valid", "CODEOWNERS file should have valid syntax", node=node)
     with c:
-        if not c.get_value(".ownership.codeowners.exists"):
+        codeowners = c.get_node(".ownership.codeowners")
+        if not codeowners.exists():
+            c.skip("No codeowners data collected")
+            return c
+
+        if not codeowners.get_value(".exists"):
             c.fail("No CODEOWNERS file found")
             return c
 
-        valid = c.get_value(".ownership.codeowners.valid")
+        valid = codeowners.get_value(".valid")
         if valid:
             return c
 
-        errors = c.get_value_or_default(".ownership.codeowners.errors", [])
+        errors = codeowners.get_value_or_default(".errors", [])
         for err in errors:
             line = err.get("line", "?")
             message = err.get("message", "Unknown error")


### PR DESCRIPTION
## Summary

- All 8 codeowners policies (`exists`, `valid`, `catchall`, `min-owners`, `max-owners`, `team-owners`, `no-individuals-only`, `no-empty-rules`) were crashing with `ValueError: No data found at path .ownership.codeowners.exists` when the codeowners collector hadn't run for a component.
- Added `c.get_node(".ownership.codeowners").exists()` guard at the top of each policy so they skip gracefully when no codeowners data has been collected — matching the pattern used by all other policies in the repo.
- Also refactored each policy to use a local `codeowners` node variable, avoiding repeated full-path lookups.

## Context

Observed on cronos.demo — all 8 codeowners policies errored on `rust-service` (SHA `537d995`) because the `.ownership.codeowners` path doesn't exist in the component JSON. The policies called `c.get_value(".ownership.codeowners.exists")` which raises `ValueError` when the parent path is absent, rather than using the safe `.exists()` method first.

## Test plan

- [ ] CI passes
- [ ] Verify on cronos.demo that codeowners policies skip (instead of erroring) for components without codeowners collector data