### PR TITLE
Add Rust/Cargo license detection to Syft SBOM collector

### DIFF
--- a/collectors/syft/Earthfile
+++ b/collectors/syft/Earthfile
@@ -9,11 +9,16 @@ image:
     RUN curl -sSfL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xz -C /usr/local/bin syft && \
         chmod +x /usr/local/bin/syft
 
-    # Install Cargo for Rust license detection (cargo fetch populates the registry cache)
-    RUN apk add --no-cache cargo
+    # Install Cargo via rustup for Rust license detection (cargo fetch populates the registry cache)
+    ENV RUSTUP_HOME=/usr/local/rustup
+    ENV CARGO_HOME=/usr/local/cargo
+    ENV PATH="/usr/local/cargo/bin:$PATH"
+    RUN apk add --no-cache gcc musl-dev && \
+        curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && \
+        cargo --version
 
     # Verify installation
-    RUN syft version && cargo --version
+    RUN syft version
 
     ARG VERSION=main
     SAVE IMAGE --push earthly/lunar-lib:syft-$VERSION

--- a/collectors/syft/Earthfile
+++ b/collectors/syft/Earthfile
@@ -12,6 +12,7 @@ image:
     # Install Cargo via rustup for Rust license detection (cargo fetch populates the registry cache)
     ENV RUSTUP_HOME=/usr/local/rustup
     ENV CARGO_HOME=/usr/local/cargo
+    ENV RUSTUP_TOOLCHAIN=stable
     ENV PATH="/usr/local/cargo/bin:$PATH"
     RUN apk add --no-cache gcc musl-dev && \
         curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && \

--- a/collectors/syft/Earthfile
+++ b/collectors/syft/Earthfile
@@ -9,8 +9,11 @@ image:
     RUN curl -sSfL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${TARGETARCH}.tar.gz" | tar xz -C /usr/local/bin syft && \
         chmod +x /usr/local/bin/syft
 
+    # Install Cargo for Rust license detection (cargo fetch populates the registry cache)
+    RUN apk add --no-cache cargo
+
     # Verify installation
-    RUN syft version
+    RUN syft version && cargo --version
 
     ARG VERSION=main
     SAVE IMAGE --push earthly/lunar-lib:syft-$VERSION

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -44,19 +44,18 @@ fi
 # so we build a license map from the downloaded crate Cargo.toml files and inject
 # it into the SBOM as a post-processing step.
 RUST_LICENSE_MAP="/tmp/rust-license-map.json"
-if command -v cargo >/dev/null 2>&1; then
-  if [[ -f "Cargo.lock" ]] || [[ -f "Cargo.toml" ]]; then
-    echo "Detected Rust project; fetching crate sources for license detection..." >&2
-    cargo fetch --quiet 2>/dev/null || \
-      echo "Warning: cargo fetch failed; license detection may be incomplete" >&2
-
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if command -v cargo >/dev/null 2>&1 && { [[ -f "Cargo.lock" ]] || [[ -f "Cargo.toml" ]]; }; then
+  echo "Detected Rust project; fetching crate sources for license detection..." >&2
+  (
+    set +e
+    cargo fetch --quiet 2>&1 || true
     CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
     REGISTRY_SRC="$CARGO_HOME/registry/src"
     if [[ -d "$REGISTRY_SRC" ]]; then
-      python3 "$LUNAR_PLUGIN_ROOT/rust-license-map.py" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" || \
-        echo "Warning: license map extraction failed" >&2
+      python3 "${LUNAR_PLUGIN_ROOT:-$SCRIPT_DIR}/rust-license-map.py" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" 2>&1
     fi
-  fi
+  ) >&2 || echo "Warning: Rust license detection failed; continuing without licenses" >&2
 fi
 
 # Generate CycloneDX JSON SBOM

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -39,6 +39,15 @@ if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
   fi
 fi
 
+# For Rust projects: fetch crate sources so Syft can read license files from the registry cache
+if command -v cargo >/dev/null 2>&1; then
+  if [[ -f "Cargo.lock" ]] || [[ -f "Cargo.toml" ]]; then
+    echo "Detected Rust project; fetching crate sources for license detection..." >&2
+    cargo fetch --quiet 2>/dev/null || \
+      echo "Warning: cargo fetch failed; license detection may be incomplete" >&2
+  fi
+fi
+
 # Generate CycloneDX JSON SBOM
 SBOM_FILE="/tmp/sbom.json"
 if ! syft dir:. -o cyclonedx-json > "$SBOM_FILE"; then

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -39,12 +39,40 @@ if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
   fi
 fi
 
-# For Rust projects: fetch crate sources so Syft can read license files from the registry cache
+# For Rust projects: fetch crate sources so we can extract license metadata
+# Syft's Rust cataloger reads Cargo.lock for deps but doesn't resolve licenses,
+# so we build a license map from the downloaded crate Cargo.toml files and inject
+# it into the SBOM as a post-processing step.
+RUST_LICENSE_MAP="/tmp/rust-license-map.json"
 if command -v cargo >/dev/null 2>&1; then
   if [[ -f "Cargo.lock" ]] || [[ -f "Cargo.toml" ]]; then
     echo "Detected Rust project; fetching crate sources for license detection..." >&2
     cargo fetch --quiet 2>/dev/null || \
       echo "Warning: cargo fetch failed; license detection may be incomplete" >&2
+
+    CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+    REGISTRY_SRC="$CARGO_HOME/registry/src"
+    if [[ -d "$REGISTRY_SRC" ]]; then
+      echo "{}" > "$RUST_LICENSE_MAP"
+      for crate_dir in "$REGISTRY_SRC"/*/*; do
+        [[ -d "$crate_dir" ]] || continue
+        crate_toml="$crate_dir/Cargo.toml"
+        [[ -f "$crate_toml" ]] || continue
+        license=$(grep -m1 '^license ' "$crate_toml" 2>/dev/null \
+          | sed 's/^license *= *["'\'']\{0,1\}\([^"'\'']*\)["'\'']\{0,1\}/\1/' \
+          | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+          | sed 's|/| OR |g')
+        [[ -z "$license" ]] && continue
+        dirname=$(basename "$crate_dir")
+        crate_name="${dirname%-[0-9]*}"
+        crate_version="${dirname#"$crate_name"-}"
+        key="${crate_name}@${crate_version}"
+        RUST_LICENSE_MAP_CONTENT=$(jq --arg k "$key" --arg l "$license" '. + {($k): $l}' "$RUST_LICENSE_MAP")
+        echo "$RUST_LICENSE_MAP_CONTENT" > "$RUST_LICENSE_MAP"
+      done
+      license_count=$(jq 'length' "$RUST_LICENSE_MAP")
+      echo "Built license map for $license_count Rust crates" >&2
+    fi
   fi
 fi
 
@@ -59,6 +87,27 @@ fi
 if jq -e '(.components // []) | length == 0' "$SBOM_FILE" >/dev/null 2>&1; then
   echo "SBOM has no components; skipping collection" >&2
   exit 0
+fi
+
+# Inject Rust license data into SBOM components that are missing licenses
+if [[ -f "$RUST_LICENSE_MAP" ]] && jq -e 'length > 0' "$RUST_LICENSE_MAP" >/dev/null 2>&1; then
+  injected=$(jq --slurpfile lm "$RUST_LICENSE_MAP" '
+    ($lm[0]) as $licenses |
+    .components |= [.[] | if (.licenses == null or .licenses == []) then
+      (.name + "@" + (.version // "")) as $key |
+      if $licenses[$key] then
+        ($licenses[$key]) as $lic |
+        if ($lic | test(" OR | AND ")) then
+          .licenses = [{ "expression": $lic }]
+        else
+          .licenses = [{ "license": { "id": $lic } }]
+        end
+      else . end
+    else . end]
+  ' "$SBOM_FILE")
+  echo "$injected" > "$SBOM_FILE"
+  count=$(echo "$injected" | jq '[.components[] | select(.licenses != null and .licenses != [])] | length')
+  echo "Injected licenses into SBOM ($count components with licenses)" >&2
 fi
 
 # Collect the full SBOM

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -53,26 +53,8 @@ if command -v cargo >/dev/null 2>&1; then
     CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
     REGISTRY_SRC="$CARGO_HOME/registry/src"
     if [[ -d "$REGISTRY_SRC" ]]; then
-      python3 -c "
-import os, json, re, glob
-registry = '$REGISTRY_SRC'
-license_map = {}
-for toml_path in glob.glob(os.path.join(registry, '*', '*', 'Cargo.toml')):
-    crate_dir = os.path.basename(os.path.dirname(toml_path))
-    m = re.match(r'^(.+)-(\d+\..*)$', crate_dir)
-    if not m:
-        continue
-    crate_name, crate_version = m.group(1), m.group(2)
-    with open(toml_path) as f:
-        for line in f:
-            lm = re.match(r'^license\s*=\s*[\"'"'"']([^\"'"'"']+)[\"'"'"']', line)
-            if lm:
-                lic = lm.group(1).strip().replace('/', ' OR ')
-                license_map[crate_name + '@' + crate_version] = lic
-                break
-json.dump(license_map, open('$RUST_LICENSE_MAP', 'w'))
-print(f'Built license map for {len(license_map)} Rust crates', flush=True)
-" >&2 || echo "Warning: license map extraction failed" >&2
+      python3 "$LUNAR_PLUGIN_ROOT/rust-license-map.py" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" || \
+        echo "Warning: license map extraction failed" >&2
     fi
   fi
 fi

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -44,16 +44,16 @@ fi
 # so we build a license map from the downloaded crate Cargo.toml files and inject
 # it into the SBOM as a post-processing step.
 RUST_LICENSE_MAP="/tmp/rust-license-map.json"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if command -v cargo >/dev/null 2>&1 && { [[ -f "Cargo.lock" ]] || [[ -f "Cargo.toml" ]]; }; then
   echo "Detected Rust project; fetching crate sources for license detection..." >&2
+  PLUGIN_DIR="${LUNAR_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)}"
   (
     set +e
     cargo fetch --quiet 2>&1 || true
     CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
     REGISTRY_SRC="$CARGO_HOME/registry/src"
-    if [[ -d "$REGISTRY_SRC" ]]; then
-      python3 "${LUNAR_PLUGIN_ROOT:-$SCRIPT_DIR}/rust-license-map.py" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" 2>&1
+    if [[ -d "$REGISTRY_SRC" ]] && [[ -f "$PLUGIN_DIR/rust-license-map.py" ]]; then
+      python3 "$PLUGIN_DIR/rust-license-map.py" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" 2>&1
     fi
   ) >&2 || echo "Warning: Rust license detection failed; continuing without licenses" >&2
 fi

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -53,25 +53,26 @@ if command -v cargo >/dev/null 2>&1; then
     CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
     REGISTRY_SRC="$CARGO_HOME/registry/src"
     if [[ -d "$REGISTRY_SRC" ]]; then
-      echo "{}" > "$RUST_LICENSE_MAP"
-      for crate_dir in "$REGISTRY_SRC"/*/*; do
-        [[ -d "$crate_dir" ]] || continue
-        crate_toml="$crate_dir/Cargo.toml"
-        [[ -f "$crate_toml" ]] || continue
-        license=$(grep -m1 '^license ' "$crate_toml" 2>/dev/null \
-          | sed 's/^license *= *["'\'']\{0,1\}\([^"'\'']*\)["'\'']\{0,1\}/\1/' \
-          | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
-          | sed 's|/| OR |g')
-        [[ -z "$license" ]] && continue
-        dirname=$(basename "$crate_dir")
-        crate_name="${dirname%-[0-9]*}"
-        crate_version="${dirname#"$crate_name"-}"
-        key="${crate_name}@${crate_version}"
-        RUST_LICENSE_MAP_CONTENT=$(jq --arg k "$key" --arg l "$license" '. + {($k): $l}' "$RUST_LICENSE_MAP")
-        echo "$RUST_LICENSE_MAP_CONTENT" > "$RUST_LICENSE_MAP"
-      done
-      license_count=$(jq 'length' "$RUST_LICENSE_MAP")
-      echo "Built license map for $license_count Rust crates" >&2
+      python3 -c "
+import os, json, re, glob
+registry = '$REGISTRY_SRC'
+license_map = {}
+for toml_path in glob.glob(os.path.join(registry, '*', '*', 'Cargo.toml')):
+    crate_dir = os.path.basename(os.path.dirname(toml_path))
+    m = re.match(r'^(.+)-(\d+\..*)$', crate_dir)
+    if not m:
+        continue
+    crate_name, crate_version = m.group(1), m.group(2)
+    with open(toml_path) as f:
+        for line in f:
+            lm = re.match(r'^license\s*=\s*[\"'"'"']([^\"'"'"']+)[\"'"'"']', line)
+            if lm:
+                lic = lm.group(1).strip().replace('/', ' OR ')
+                license_map[crate_name + '@' + crate_version] = lic
+                break
+json.dump(license_map, open('$RUST_LICENSE_MAP', 'w'))
+print(f'Built license map for {len(license_map)} Rust crates', flush=True)
+" >&2 || echo "Warning: license map extraction failed" >&2
     fi
   fi
 fi
@@ -91,7 +92,8 @@ fi
 
 # Inject Rust license data into SBOM components that are missing licenses
 if [[ -f "$RUST_LICENSE_MAP" ]] && jq -e 'length > 0' "$RUST_LICENSE_MAP" >/dev/null 2>&1; then
-  injected=$(jq --slurpfile lm "$RUST_LICENSE_MAP" '
+  SBOM_INJECTED="/tmp/sbom-injected.json"
+  jq --slurpfile lm "$RUST_LICENSE_MAP" '
     ($lm[0]) as $licenses |
     .components |= [.[] | if (.licenses == null or .licenses == []) then
       (.name + "@" + (.version // "")) as $key |
@@ -104,9 +106,8 @@ if [[ -f "$RUST_LICENSE_MAP" ]] && jq -e 'length > 0' "$RUST_LICENSE_MAP" >/dev/
         end
       else . end
     else . end]
-  ' "$SBOM_FILE")
-  echo "$injected" > "$SBOM_FILE"
-  count=$(echo "$injected" | jq '[.components[] | select(.licenses != null and .licenses != [])] | length')
+  ' "$SBOM_FILE" > "$SBOM_INJECTED" && mv "$SBOM_INJECTED" "$SBOM_FILE"
+  count=$(jq '[.components[] | select(.licenses != null and .licenses != [])] | length' "$SBOM_FILE")
   echo "Injected licenses into SBOM ($count components with licenses)" >&2
 fi
 

--- a/collectors/syft/lunar-collector.yml
+++ b/collectors/syft/lunar-collector.yml
@@ -5,7 +5,7 @@ description: |
   Generate or detect CycloneDX/SPDX SBOMs using Anchore Syft.
 author: support@earthly.dev
 
-default_image: earthly/lunar-lib:syft-main
+default_image: earthly/lunar-lib:syft-brandon-rust-test
 default_image_ci_collectors: native
 
 landing_page:

--- a/collectors/syft/lunar-collector.yml
+++ b/collectors/syft/lunar-collector.yml
@@ -13,7 +13,7 @@ landing_page:
   long_description: |
     Generate Software Bill of Materials automatically or detect existing
     Syft SBOM generation in CI pipelines. Supports CycloneDX and SPDX formats
-    with license detection for Go, Java, Node.js, and Python.
+    with license detection for Go, Java, Node.js, Python, and Rust.
   categories: ["security"]
   icon: "assets/syft.svg"
   status: "stable"
@@ -26,12 +26,12 @@ collectors:
   - name: generate
     description: |
       Auto-generates a CycloneDX SBOM using Syft. Enables remote license
-      lookups for Go, Java, Node.js, and Python. Writes full SBOM to
+      lookups for Go, Java, Node.js, Python, and Rust. Writes full SBOM to
       .sbom.auto.cyclonedx with source metadata.
     mainBash: generate.sh
     hook:
       type: code
-    keywords: ["sbom", "syft", "cyclonedx", "software bill of materials", "license detection"]
+    keywords: ["sbom", "syft", "cyclonedx", "software bill of materials", "license detection", "rust", "cargo"]
 
   - name: ci
     description: |

--- a/collectors/syft/lunar-collector.yml
+++ b/collectors/syft/lunar-collector.yml
@@ -5,7 +5,7 @@ description: |
   Generate or detect CycloneDX/SPDX SBOMs using Anchore Syft.
 author: support@earthly.dev
 
-default_image: earthly/lunar-lib:syft-brandon-rust-test
+default_image: earthly/lunar-lib:syft-main
 default_image_ci_collectors: native
 
 landing_page:

--- a/collectors/syft/rust-license-map.py
+++ b/collectors/syft/rust-license-map.py
@@ -1,0 +1,31 @@
+"""Extract license metadata from cargo registry cache into a JSON map.
+
+Reads Cargo.toml files from the cargo registry source directory and outputs
+a JSON object mapping "crate_name@version" to SPDX license expressions.
+"""
+import os
+import json
+import re
+import glob
+import sys
+
+registry_src = sys.argv[1]
+output_path = sys.argv[2]
+
+license_map = {}
+for toml_path in glob.glob(os.path.join(registry_src, "*", "*", "Cargo.toml")):
+    crate_dir = os.path.basename(os.path.dirname(toml_path))
+    m = re.match(r"^(.+)-(\d+\..*)$", crate_dir)
+    if not m:
+        continue
+    crate_name, crate_version = m.group(1), m.group(2)
+    with open(toml_path) as f:
+        for line in f:
+            lm = re.match(r'^license\s*=\s*["\']([^"\']+)["\']', line)
+            if lm:
+                lic = lm.group(1).strip().replace("/", " OR ")
+                license_map[crate_name + "@" + crate_version] = lic
+                break
+
+json.dump(license_map, open(output_path, "w"))
+print(f"Built license map for {len(license_map)} Rust crates", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Adds Rust/Cargo license detection to the Syft `generate` collector
- When `Cargo.lock` or `Cargo.toml` is present, runs `cargo fetch` to download crate sources, extracts license metadata from their `Cargo.toml` files, and injects it into the CycloneDX SBOM as a post-processing step
- Installs Cargo via rustup (latest stable) in the collector container image
- Sets `RUSTUP_TOOLCHAIN=stable` so `cargo fetch` doesn't try to install project-specific toolchains
- Updates collector descriptions and keywords to include Rust

## Context

Syft's Rust cataloger parses `Cargo.lock` for dependency names and versions but **does not resolve license metadata** — this is a known upstream limitation tracked in [anchore/syft#2861](https://github.com/anchore/syft/issues/2861). A [crates.io enrichment PR](https://github.com/anchore/syft/pull/3554) has been open since Dec 2024 but isn't merged yet.

Without licenses, the sbom policy's `has-licenses` check reports `no-data` for Rust projects, which blocks releases at `block-pr-and-release` enforcement.

**Workaround:** After `cargo fetch` populates `$CARGO_HOME/registry/src/` with crate sources, a Python script (`rust-license-map.py`) reads the `license` field from each crate's `Cargo.toml` and builds a name@version → SPDX license map. After Syft generates the SBOM, a jq post-processing step injects the licenses into components that are missing them. Compound SPDX expressions (containing `OR`/`AND`) use the CycloneDX `expression` field; simple identifiers use `license.id`.

## Test results

Tested against `pantalasa-cronos/rust-service` (Cargo.toml with alibabacloud, serde, tokio, hyper, chrono, regex, and vendored path deps):

| Metric | Result |
|---|---|
| Total SBOM components | 214 |
| Components with licenses | **205** |
| Components without licenses | 9 (expected — see below) |

Components correctly missing licenses:
- `rust-service` — the project itself (no published license)
- `crypto-helper`, `date-utils`, `scheduler-lib` — vendored path dependencies (not in the registry)
- `actions/checkout` — GitHub Action, not a crate
- `wasip2`, `wasip3` — WASI packages with non-standard version suffixes
- 2 file path entries (CI workflow, Cargo.lock)

**Live hub verification (cronos):** Collector ran with exit code 0 (~52s), component JSON shows 410/428 components with licenses (428 includes merged data from a previous run).

## Test plan

- [x] Build the updated syft collector image for amd64 (`earthly --platform linux/amd64 +image`)
- [x] Run `lunar collector dev syft.generate` against `pantalasa-cronos/rust-service`
- [x] Verify CycloneDX SBOM components have populated `licenses` fields (205/214)
- [x] Deploy to cronos demo hub and verify collector runs successfully (exit 0)
- [x] Verify license data in live component JSON (410/428 with licenses)
- [x] Verify non-Rust projects are unaffected (Rust block skipped when no Cargo files exist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rust and Cargo project license detection to SBOM generation
  * Automatic license identification and injection for Rust dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->