### PR TITLE
Fix collectors querying removed components_latest2 view

### DIFF
--- a/collectors/jira/ticket-history.sh
+++ b/collectors/jira/ticket-history.sh
@@ -47,7 +47,7 @@ SAFE_PR=$(echo "$LUNAR_COMPONENT_PR" | sed "s/'/''/g")
 # Query for other PRs using the same ticket.
 QUERY="
   SELECT COUNT(DISTINCT (component_id, pr))
-  FROM components_latest2
+  FROM components_latest
   WHERE pr IS NOT NULL
     AND component_json->'vcs'->'pr'->'ticket'->>'id' = '${SAFE_TICKET_KEY}'
     AND NOT (component_id = '${SAFE_COMPONENT_ID}' AND pr::text = '${SAFE_PR}')

--- a/collectors/semgrep/running-in-prs.sh
+++ b/collectors/semgrep/running-in-prs.sh
@@ -17,7 +17,7 @@ source "$(dirname "$0")/helpers.sh"
 #
 # HOW IT WORKS:
 # 1. Get DB connection via `lunar sql connection-string`
-# 2. Query components_latest2 for PRs with Semgrep data for this component
+# 2. Query components_latest for PRs with Semgrep data for this component
 # 3. If found, write proof to Component JSON that scanning is happening
 #
 # =============================================================================
@@ -42,12 +42,11 @@ fi
 SAFE_COMPONENT_ID=$(echo "$LUNAR_COMPONENT_ID" | sed "s/'/''/g")
 
 for CATEGORY in sast sca; do
-    # Query components_latest2 for PR data with Semgrep results.
-    # Note: using components_latest2 due to temporary schema limitation.
+    # Query components_latest for PR data with Semgrep results.
     QUERY="
         SELECT EXISTS (
             SELECT 1
-            FROM components_latest2 pr
+            FROM components_latest pr
             WHERE pr.component_id = '$SAFE_COMPONENT_ID'
               AND pr.pr IS NOT NULL
               AND (pr.component_json->'$CATEGORY'->'native'->'semgrep') IS NOT NULL

--- a/collectors/snyk/running-in-prs.sh
+++ b/collectors/snyk/running-in-prs.sh
@@ -17,7 +17,7 @@ source "$(dirname "$0")/helpers.sh"
 #
 # HOW IT WORKS:
 # 1. Get DB connection via `lunar sql connection-string`
-# 2. Query components_latest2 for PRs with Snyk data for this component
+# 2. Query components_latest for PRs with Snyk data for this component
 # 3. If found, write proof to Component JSON that scanning is happening
 #
 # =============================================================================
@@ -42,12 +42,11 @@ fi
 SAFE_COMPONENT_ID=$(echo "$LUNAR_COMPONENT_ID" | sed "s/'/''/g")
 
 for CATEGORY in sca sast container_scan iac_scan; do
-    # Query components_latest2 for PR data with Snyk results.
-    # Note: using components_latest2 due to temporary schema limitation.
+    # Query components_latest for PR data with Snyk results.
     QUERY="
         SELECT EXISTS (
             SELECT 1
-            FROM components_latest2 pr
+            FROM components_latest pr
             WHERE pr.component_id = '$SAFE_COMPONENT_ID'
               AND pr.pr IS NOT NULL
               AND (pr.component_json->'$CATEGORY'->'native'->'snyk') IS NOT NULL


### PR DESCRIPTION
## Summary
- Rename `components_latest2` → `components_latest` in three collectors that query the hub database via `lunar sql`
- Affected collectors: `jira/ticket-history`, `snyk/running-in-prs`, `semgrep/running-in-prs`
- The `components_latest2` view was consolidated into `components_latest` in lunar PR #1055 (ENG-276). These collectors were missed in that migration and have been silently failing ever since.

## Test plan
- [ ] Verify `ticket-reuse` policy fires on a PR reusing a Jira ticket (e.g. DP-3 on pantalasa-cronos/backend)
- [ ] Verify `snyk/running-in-prs` and `semgrep/running-in-prs` collectors write data on default branch runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend data collection infrastructure across Jira, Semgrep, and Snyk integrations to use current database sources for improved data consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->