### PR TITLE
Fix Rust collector bash bugs causing failures across all components

### DIFF
--- a/collectors/rust/project.sh
+++ b/collectors/rust/project.sh
@@ -22,9 +22,9 @@ version=""
 # Core file detection
 [[ -f "Cargo.toml" ]] && cargo_toml_exists=true
 [[ -f "Cargo.lock" ]] && cargo_lock_exists=true
-[[ -f "rust-toolchain.toml" ]] || [[ -f "rust-toolchain" ]] && rust_toolchain_exists=true
-[[ -f "clippy.toml" ]] || [[ -f ".clippy.toml" ]] && clippy_configured=true
-[[ -f "rustfmt.toml" ]] || [[ -f ".rustfmt.toml" ]] && rustfmt_configured=true
+if [[ -f "rust-toolchain.toml" ]] || [[ -f "rust-toolchain" ]]; then rust_toolchain_exists=true; fi
+if [[ -f "clippy.toml" ]] || [[ -f ".clippy.toml" ]]; then clippy_configured=true; fi
+if [[ -f "rustfmt.toml" ]] || [[ -f ".rustfmt.toml" ]]; then rustfmt_configured=true; fi
 
 # Parse Cargo.toml for metadata (POSIX-compatible, no grep -P)
 if [[ "$cargo_toml_exists" == "true" ]]; then

--- a/collectors/rust/test-coverage.sh
+++ b/collectors/rust/test-coverage.sh
@@ -24,7 +24,7 @@ if [[ "$CMD_STR" == *"tarpaulin"* ]]; then
     fi
     # Fallback: parse from CI output if available via LUNAR_CI_OUTPUT
     if [[ -z "$coverage_pct" ]] && [[ -n "$LUNAR_CI_OUTPUT" ]]; then
-        coverage_pct=$(echo "$LUNAR_CI_OUTPUT" | grep -oP '[\d.]+(?=% coverage)' | tail -1 || true)
+        coverage_pct=$(echo "$LUNAR_CI_OUTPUT" | sed -n 's/.*\([0-9][0-9]*\.[0-9]*\)% coverage.*/\1/p' | tail -1 || true)
     fi
 fi
 


### PR DESCRIPTION
## Summary

- **Fix `set -e` crash in `project.sh`**: Lines 25-27 used `[[ -f A ]] || [[ -f B ]] && var=true` which exits the script when neither file exists. In bash, `||` and `&&` have equal precedence (left-to-right), so when both tests fail the compound command returns non-zero and `set -e` kills the script. Since `project.sh` writes foundational data to `.lang.rust`, this breaks every downstream sub-collector and policy. Replaced with proper `if/then/fi` blocks.

- **Fix non-portable `grep -oP` in `test-coverage.sh`**: Perl-compatible regex (`-P` flag) is not available on Alpine/BusyBox grep or all CI runner environments. Replaced with portable `sed` expression.

## Test plan

- [x] `lunar collector dev rust.project --component-dir ../rust-service` — passes, outputs correct JSON with `rustfmt_configured: false`
- [x] `lunar collector dev rust.dependencies --component-dir ../rust-service` — passes, outputs correct dependency tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code clarity in Rust project detection logic.
  * Enhanced test coverage data extraction parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->