### PR TITLE
Fix syft CI collector never collecting SBOM files

### DIFF
--- a/collectors/syft/ci.sh
+++ b/collectors/syft/ci.sh
@@ -1,31 +1,30 @@
 #!/bin/bash
 set -e
 
-CMD="$LUNAR_CI_COMMAND"
+CMD_RAW="$LUNAR_CI_COMMAND"
 
-# Extract command string for cmds array
-CMD_STR=$(echo "$CMD" | sed 's/^\[//; s/\]$//; s/","/ /g; s/"//g')
-CMD_STR=$(printf '%s' "$CMD_STR" | sed 's/\\/\\\\/g; s/"/\\"/g')
+# Convert JSON array to plain command string for parsing
+CMD=$(echo "$CMD_RAW" | sed 's/^\[//; s/\]$//; s/","/ /g; s/"//g')
+# Escaped version for safe JSON embedding
+CMD_ESC=$(printf '%s' "$CMD" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
 # Get syft version using the exact traced binary
 SYFT_BIN="${LUNAR_CI_COMMAND_BIN_DIR:+$LUNAR_CI_COMMAND_BIN_DIR/}${LUNAR_CI_COMMAND_BIN:-syft}"
 VERSION=$("$SYFT_BIN" version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "")
 
-# Write tool-specific CI metadata under .sbom.native.syft.cicd
-# This follows the .native.{tool}.cicd convention (matching Snyk, manifest-cyber)
 if [ -n "$VERSION" ]; then
-  lunar collect -j ".sbom.native.syft.cicd.cmds" "[{\"cmd\":\"$CMD_STR\",\"version\":\"$VERSION\"}]"
+  lunar collect -j ".sbom.native.syft.cicd.cmds" "[{\"cmd\":\"$CMD_ESC\",\"version\":\"$VERSION\"}]"
 else
-  lunar collect -j ".sbom.native.syft.cicd.cmds" "[{\"cmd\":\"$CMD_STR\"}]"
+  lunar collect -j ".sbom.native.syft.cicd.cmds" "[{\"cmd\":\"$CMD_ESC\"}]"
 fi
 
-# Parse the command to find output file and format
-# Syft output flags: -o/--output <format>=<file> or -o <format> with stdout
+# Parse the command to find output file and format.
+# All regex matching operates on $CMD (plain space-separated string),
+# not $CMD_RAW (JSON array where elements are separated by "," not spaces).
 OUTPUT_FILE=""
 OUTPUT_FORMAT=""
 
-# Match patterns like: -o cyclonedx-json=sbom.json, --output spdx-json@1.6=report.json
-# Supports: simple (json), hyphenated (cyclonedx-json), versioned (cyclonedx-json@1.6)
+# 1) -o cyclonedx-json=sbom.json, --output spdx-json@1.6=report.json
 if echo "$CMD" | grep -qoE '(-o|--output)\s+[a-z]+(-[a-z]+)?(@[0-9.]+)?=\S+'; then
   MATCH=$(echo "$CMD" | grep -oE '(-o|--output)\s+[a-z]+(-[a-z]+)?(@[0-9.]+)?=\S+' | head -1)
   FORMAT_FILE=$(echo "$MATCH" | sed -E 's/(-o|--output)\s+//')
@@ -33,24 +32,70 @@ if echo "$CMD" | grep -qoE '(-o|--output)\s+[a-z]+(-[a-z]+)?(@[0-9.]+)?=\S+'; th
   OUTPUT_FILE=$(echo "$FORMAT_FILE" | cut -d'=' -f2)
 fi
 
-# Match patterns like: -o cyclonedx-json, -o json, -o spdx-json@2.3
+# 2) -o cyclonedx-json (no file — stdout)
 if [ -z "$OUTPUT_FORMAT" ]; then
   if echo "$CMD" | grep -qoE '(-o|--output)\s+[a-z]+(-[a-z]+)?(@[0-9.]+)?(\s|$)'; then
     OUTPUT_FORMAT=$(echo "$CMD" | grep -oE '(-o|--output)\s+[a-z]+(-[a-z]+)?(@[0-9.]+)?' | head -1 | sed -E 's/(-o|--output)\s+//' | sed 's/@.*//')
   fi
 fi
 
-# Try to detect redirect: syft ... > file.json
+# 3) Deprecated --file flag (still used by some workflows)
+if [ -z "$OUTPUT_FILE" ]; then
+  if echo "$CMD" | grep -qoE '(--file)\s+\S+'; then
+    OUTPUT_FILE=$(echo "$CMD" | grep -oE '(--file)\s+(\S+)' | head -1 | sed -E 's/--file\s+//')
+  fi
+fi
+
+# 4) Shell redirect: syft ... > file.json
 if [ -z "$OUTPUT_FILE" ]; then
   if echo "$CMD" | grep -qoE '>\s*\S+\.json'; then
     OUTPUT_FILE=$(echo "$CMD" | grep -oE '>\s*(\S+\.json)' | head -1 | sed 's/>\s*//')
   fi
 fi
 
-# Determine the SBOM format — only collect JSON formats we recognize
-# SBOM content goes to normalized .sbom.cicd paths (tool-agnostic)
-# Syft formats: json (native), cyclonedx-json, cyclonedx-xml, spdx-json, spdx-tag-value,
-#               github-json, table, text, purls, template
+# 5) Fallback: when syft writes to stdout (no =file, no --file, no redirect), GH Actions
+# like anchore-sbom-action capture stdout and write it to a temp file. Search for recently
+# created SBOM files in known locations.
+if [ -z "$OUTPUT_FILE" ] && [ -n "$OUTPUT_FORMAT" ]; then
+  find_sbom_file() {
+    local candidates=""
+    for d in /tmp/sbom-action-*; do
+      [ -d "$d" ] && candidates="$candidates $(ls -t "$d"/*.spdx "$d"/*.json "$d"/*.spdx.json "$d"/*.cyclonedx.json 2>/dev/null | head -3)"
+    done
+    for dir in "${GITHUB_WORKSPACE:-.}" "${RUNNER_TEMP:-}" "/tmp"; do
+      [ -z "$dir" ] || [ ! -d "$dir" ] && continue
+      for pattern in "sbom*.json" "*.sbom.json" "*.cyclonedx.json" "*.spdx.json"; do
+        candidates="$candidates $(ls -t "$dir"/$pattern 2>/dev/null | head -3)"
+      done
+    done
+    for f in $candidates; do
+      [ -f "$f" ] || continue
+      if head -c 2048 "$f" | grep -qE '"bomFormat"|"spdxVersion"|"BOMFormat"' 2>/dev/null; then
+        echo "$f"
+        return 0
+      fi
+    done
+    return 1
+  }
+  OUTPUT_FILE=$(find_sbom_file 2>/dev/null) || true
+  if [ -z "$OUTPUT_FILE" ]; then
+    sleep 1
+    OUTPUT_FILE=$(find_sbom_file 2>/dev/null) || true
+  fi
+  if [ -n "$OUTPUT_FILE" ]; then
+    echo "Found SBOM file via fallback search: $OUTPUT_FILE" >&2
+  fi
+fi
+
+# If we found a file but don't know the format, auto-detect from content.
+if [ -z "$OUTPUT_FORMAT" ] && [ -n "$OUTPUT_FILE" ] && [ -f "$OUTPUT_FILE" ]; then
+  if head -c 2048 "$OUTPUT_FILE" | grep -q '"bomFormat"' 2>/dev/null; then
+    OUTPUT_FORMAT="cyclonedx-json"
+  elif head -c 2048 "$OUTPUT_FILE" | grep -q '"spdxVersion"' 2>/dev/null; then
+    OUTPUT_FORMAT="spdx-json"
+  fi
+fi
+
 SBOM_PATH=""
 case "$OUTPUT_FORMAT" in
   cyclonedx-json)
@@ -60,21 +105,19 @@ case "$OUTPUT_FORMAT" in
     SBOM_PATH=".sbom.cicd.spdx"
     ;;
   json)
-    # Syft native JSON format — tool-specific, goes under native
     SBOM_PATH=".sbom.native.syft.cicd.raw"
     ;;
   github-json)
     SBOM_PATH=".sbom.native.syft.cicd.github"
     ;;
-  # XML and text formats (cyclonedx-xml, spdx-tag-value, table, text, purls, template)
-  # are not collected — lunar collect requires JSON
 esac
 
-# If we found an output file AND know the format, collect it
 if [ -n "$SBOM_PATH" ] && [ -n "$OUTPUT_FILE" ] && [ -f "$OUTPUT_FILE" ]; then
   echo "Collecting SBOM from $OUTPUT_FILE (format: $OUTPUT_FORMAT)" >&2
   cat "$OUTPUT_FILE" | lunar collect -j "$SBOM_PATH" - || \
     echo "Warning: Failed to collect SBOM from $OUTPUT_FILE" >&2
+elif [ -n "$SBOM_PATH" ] && [ -z "$OUTPUT_FILE" ]; then
+  echo "Syft wrote to stdout; no output file found to collect (format: $OUTPUT_FORMAT)" >&2
 elif [ -n "$OUTPUT_FILE" ] && [ -f "$OUTPUT_FILE" ]; then
   echo "Skipping SBOM file collection: unknown format '$OUTPUT_FORMAT'" >&2
 fi

--- a/collectors/syft/generate.sh
+++ b/collectors/syft/generate.sh
@@ -46,14 +46,21 @@ fi
 RUST_LICENSE_MAP="/tmp/rust-license-map.json"
 if command -v cargo >/dev/null 2>&1 && { [[ -f "Cargo.lock" ]] || [[ -f "Cargo.toml" ]]; }; then
   echo "Detected Rust project; fetching crate sources for license detection..." >&2
-  PLUGIN_DIR="${LUNAR_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)}"
+  PLUGIN_DIR="${LUNAR_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)}"
   (
     set +e
     cargo fetch --quiet 2>&1 || true
     CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
     REGISTRY_SRC="$CARGO_HOME/registry/src"
-    if [[ -d "$REGISTRY_SRC" ]] && [[ -f "$PLUGIN_DIR/rust-license-map.py" ]]; then
-      python3 "$PLUGIN_DIR/rust-license-map.py" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" 2>&1
+    if [[ -d "$REGISTRY_SRC" ]]; then
+      SCRIPT="$PLUGIN_DIR/rust-license-map.py"
+      if [[ ! -f "$SCRIPT" ]]; then
+        echo "rust-license-map.py not found at $SCRIPT (LUNAR_PLUGIN_ROOT=$LUNAR_PLUGIN_ROOT)" >&2
+      else
+        python3 "$SCRIPT" "$REGISTRY_SRC" "$RUST_LICENSE_MAP" 2>&1
+      fi
+    else
+      echo "No registry src dir at $REGISTRY_SRC" >&2
     fi
   ) >&2 || echo "Warning: Rust license detection failed; continuing without licenses" >&2
 fi


### PR DESCRIPTION
## Summary

The `syft.ci` collector was never collecting actual SBOM files from CI pipelines. It traced commands correctly (visible in `.sbom.native.syft.cicd.cmds`) but the SBOM content was never written to `.sbom.cicd.cyclonedx` or `.sbom.cicd.spdx`.

## Root Cause

All regex parsing operated on `$LUNAR_CI_COMMAND` directly — a JSON array like `["syft","dir:.","-o","cyclonedx-json=sbom.json"]`. Patterns like `-o\s+cyclonedx-json` require whitespace between `-o` and the format, but JSON array elements are separated by `","` not spaces. So `OUTPUT_FORMAT` and `OUTPUT_FILE` were always empty.

## Fix

- Convert the JSON array to a plain space-separated string before regex matching
- Add deprecated `--file` flag detection
- Add fallback file search for stdout-only invocations (covers `anchore-sbom-action` and similar GH Actions that capture syft stdout and write it to temp files)
- Add 1s retry on fallback search to cover parent-process flush race
- Add format auto-detection from file content

## Testing

Tested on `pantalasa-cronos/backend` with three syft invocation patterns:

| Pattern | Result |
|---------|--------|
| `syft dir:. -o cyclonedx-json=sbom.cyclonedx.json` (explicit file output) | 12,850 bytes CycloneDX SBOM collected |
| `syft dir:. -o cyclonedx-json > file` (stdout via shell redirect) | 11,756 bytes CycloneDX SBOM collected via fallback search |
| `anchore/sbom-action@v0` with `format: cyclonedx-json` (GH Action wrapper, stdout capture) | 12,850 bytes CycloneDX SBOM collected via fallback search |

The third case uses the same `anchore/sbom-action` pattern as the user who reported the issue. The action installs syft to `_work/_tool/syft/1.42.3/` and invokes it with `-o cyclonedx-json` (stdout), then writes the result to a temp file. The fallback search + 1s retry successfully found and collected the SBOM.

🤖 *This PR was implemented by an AI agent.*