### PR TITLE
Replace CodeRabbit with Claude Code Review

### DIFF
--- a/.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md
+++ b/.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md
@@ -408,7 +408,7 @@ Commit and push the implementation to the same PR branch. CI will run automatica
 
 ### Then wait for approval
 
-CodeRabbit will automatically review the PR. Address its feedback, but **use judgment** — CodeRabbit sometimes flags things that aren't real issues or suggests unnecessary changes. If a comment is wrong or irrelevant, reply explaining why and resolve the thread. When you've addressed a valid comment (pushed a fix), resolve that thread too. Don't leave conversations hanging. CodeRabbit learns from your replies, so always respond — even to dismiss a false positive.
+Claude will automatically review the PR via the `claude-code-action` GitHub Action. Address its feedback, but **use judgment** — Claude sometimes flags things that aren't real issues. If a comment is wrong or irrelevant, reply explaining why and resolve the thread. When you've addressed a valid comment (pushed a fix), resolve that thread too. Don't leave conversations hanging. You can also `@claude` in a PR comment to ask it questions about the code.
 
 **Implementation review may trigger spec changes.** Reviewers may ask you to adjust the YAML manifest, README, or Component JSON paths even after implementation is added. This is normal — make the changes. **Re-test after significant changes** (logic changes, new assertions, changed Component JSON paths). A quick `lunar collector dev` or `lunar policy dev` run is enough — post updated results on the PR if the previous results are now stale.
 
@@ -426,7 +426,7 @@ Wait for the **requester** to approve the implementation (or merge directly). Th
 ### Pre-merge checklist
 
 - [ ] CI is green
-- [ ] CodeRabbit comments addressed
+- [ ] Claude review comments addressed
 - [ ] **Requester approved** (or is merging directly)
 - [ ] Test results posted on PR
 - [ ] No unresolved review threads / suggestions
@@ -504,7 +504,7 @@ These are the most frequent mistakes AI agents make on lunar-lib PRs. Read this 
 | Using `git add .` or `git add -A` | Stages unintended files (test configs, temp files, etc.). | Always `git add` specific directories: `git add collectors/<name>/` or `git add policies/<name>/`. |
 | Merging without requester's approval | The requester reviews implementation and must approve (or merge directly) before merging. | Wait for the requester's approval on the implementation. |
 | Not posting test results on the PR | Reviewers need evidence, not trust. | Always post a test results comment with the template from this playbook. |
-| Ignoring CodeRabbit feedback | CodeRabbit auto-reviews open PRs. Unresolved comments slow down human review. | Address or reply to every CodeRabbit comment before requesting human review. |
+| Ignoring Claude review feedback | Claude auto-reviews open PRs. Unresolved comments slow down human review. | Address or reply to every Claude review comment before requesting human review. |
 
 ### Docker images
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: opus
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Review this pull request. Focus on:
+            - Correctness and potential bugs
+            - Security issues (hardcoded secrets, injection, unsafe patterns)
+            - Adherence to the coding standards in AGENTS.md
+            - Component JSON conventions (object presence as signal, no redundant booleans, categories describe WHAT not HOW)
+            - Shell script compatibility (Alpine/BusyBox — no GNU grep extensions)
+            - Policy patterns (skip vs fail, exists() before get_value(), no dead code after skip())
+
+            Be concise. Only flag real issues — not style preferences or nitpicks.
+            Use inline comments for code-specific feedback.
+            Post a brief summary comment with your overall assessment.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"


### PR DESCRIPTION
## Summary

- Adds `claude-code-action` GitHub Action workflow for automated PR reviews, replacing CodeRabbit
- Claude auto-reviews PRs on open/sync/ready_for_review and responds to `@claude` mentions in comments
- Uses Opus model with a prompt tailored to lunar-lib conventions (Component JSON patterns, Alpine/BusyBox compatibility, policy skip/fail patterns)
- Updates playbook references from CodeRabbit to Claude

## Changes

- **New:** `.github/workflows/claude.yml` — claude-code-action workflow
- **Updated:** `.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md` — replaced CodeRabbit references with Claude

## Prerequisites

- `ANTHROPIC_API_KEY` must be set as a repo secret (already exists from the auto-approve workflow)
- After merging, uninstall the CodeRabbit GitHub App from the org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review process to use Claude for PR reviews instead of the previous tool.
  * Added GitHub Actions workflow to enable automated Claude-based code review on pull requests, with support for manual invocation via comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->