### PR TITLE
Fix GitHub collector early-exit logging and VCS policy pending state

### DIFF
--- a/collectors/github/access_permissions.sh
+++ b/collectors/github/access_permissions.sh
@@ -14,11 +14,6 @@ if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
   exit 1
 fi
 
-if [ -z "$LUNAR_COMPONENT_ID" ]; then
-  echo "Error: LUNAR_COMPONENT_ID is not set" >&2
-  exit 1
-fi
-
 # LUNAR_COMPONENT_ID should be in format "github.com/owner/repo"
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)

--- a/collectors/github/access_permissions.sh
+++ b/collectors/github/access_permissions.sh
@@ -2,18 +2,27 @@
 
 set -e
 
+echo "[DEBUG] access_permissions.sh starting" >&2
+echo "[DEBUG] LUNAR_COMPONENT_ID=${LUNAR_COMPONENT_ID:-<unset>}" >&2
+echo "[DEBUG] LUNAR_SECRET_GH_TOKEN set: $([ -n "$LUNAR_SECRET_GH_TOKEN" ] && echo 'yes' || echo 'no')" >&2
+echo "[DEBUG] LUNAR_SECRET_GH_TOKEN length: ${#LUNAR_SECRET_GH_TOKEN}" >&2
+
 # Only process GitHub repositories
 if [[ ! "$LUNAR_COMPONENT_ID" =~ ^github\.com/ ]]; then
+  echo "[DEBUG] LUNAR_COMPONENT_ID does not match ^github.com/ — exiting 0" >&2
   exit 0
 fi
+echo "[DEBUG] Component ID matches github.com pattern" >&2
 
 # Check for required environment variables
 if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
+  echo "[DEBUG] LUNAR_SECRET_GH_TOKEN is empty — exiting 1" >&2
   echo "Error: LUNAR_SECRET_GH_TOKEN is not set" >&2
   exit 1
 fi
 
 if [ -z "$LUNAR_COMPONENT_ID" ]; then
+  echo "[DEBUG] LUNAR_COMPONENT_ID is empty — exiting 1" >&2
   echo "Error: LUNAR_COMPONENT_ID is not set" >&2
   exit 1
 fi
@@ -22,6 +31,7 @@ fi
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)
 REPO=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f3)
+echo "[DEBUG] Parsed OWNER=$OWNER REPO=$REPO" >&2
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Error: Could not parse LUNAR_COMPONENT_ID='$LUNAR_COMPONENT_ID' (expected format: github.com/owner/repo)" >&2
@@ -40,14 +50,30 @@ gh_api() {
   local all_data="[]"
   local page=1
 
+  echo "[DEBUG] gh_api (paginated): starting GET $url" >&2
+
   while true; do
-    local response=$(curl -sSL -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
+    local full_url="${url}?per_page=100&page=${page}"
+    echo "[DEBUG] gh_api: GET $full_url" >&2
+
+    local response
+    local http_code
+    response=$(curl -sSL -w "\n%{http_code}" -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
          -H "Accept: application/vnd.github+json" \
          -H "X-GitHub-Api-Version: 2022-11-28" \
-         "${url}?per_page=100&page=${page}")
+         "$full_url")
+    http_code=$(echo "$response" | tail -1)
+    response=$(echo "$response" | sed '$d')
+    echo "[DEBUG] gh_api: HTTP $http_code (response length: ${#response})" >&2
+
+    if [ "$http_code" -ge 400 ] 2>/dev/null; then
+      echo "[DEBUG] gh_api: ERROR response: $(echo "$response" | head -c 500)" >&2
+      break
+    fi
 
     # Check if response is an array and not empty
     local item_count=$(echo "$response" | jq 'if type == "array" then length else 0 end')
+    echo "[DEBUG] gh_api: page $page returned $item_count items" >&2
 
     if [ "$item_count" -eq 0 ]; then
       break
@@ -63,10 +89,11 @@ gh_api() {
     page=$((page + 1))
   done
 
+  echo "[DEBUG] gh_api: total items collected: $(echo "$all_data" | jq length)" >&2
   echo "$all_data"
 }
 
-# Fetch direct collaborators
+echo "[DEBUG] Fetching collaborators for ${OWNER}/${REPO}" >&2
 COLLABORATORS_DATA=$(gh_api "/repos/${OWNER}/${REPO}/collaborators")
 
 # Extract collaborator information (login and permissions)
@@ -82,8 +109,9 @@ COLLABORATORS=$(echo "$COLLABORATORS_DATA" | jq '[.[] | {
     end,
   type: .type
 }]')
+echo "[DEBUG] Parsed $(echo "$COLLABORATORS" | jq length) collaborators" >&2
 
-# Fetch teams with access
+echo "[DEBUG] Fetching teams for ${OWNER}/${REPO}" >&2
 TEAMS_DATA=$(gh_api "/repos/${OWNER}/${REPO}/teams")
 
 # Extract team information (slug and permission)
@@ -92,7 +120,10 @@ TEAMS=$(echo "$TEAMS_DATA" | jq '[.[] | {
   name: .name,
   permission: .permission
 }]')
+echo "[DEBUG] Parsed $(echo "$TEAMS" | jq length) teams" >&2
 
-# Collect access permissions using dot notation
+echo "[DEBUG] Collecting access permissions data..." >&2
 echo "$COLLABORATORS" | lunar collect -j ".vcs.access.collaborators" -
 echo "$TEAMS" | lunar collect -j ".vcs.access.teams" -
+
+echo "[DEBUG] access_permissions.sh completed successfully" >&2

--- a/collectors/github/access_permissions.sh
+++ b/collectors/github/access_permissions.sh
@@ -2,27 +2,19 @@
 
 set -e
 
-echo "[DEBUG] access_permissions.sh starting" >&2
-echo "[DEBUG] LUNAR_COMPONENT_ID=${LUNAR_COMPONENT_ID:-<unset>}" >&2
-echo "[DEBUG] LUNAR_SECRET_GH_TOKEN set: $([ -n "$LUNAR_SECRET_GH_TOKEN" ] && echo 'yes' || echo 'no')" >&2
-echo "[DEBUG] LUNAR_SECRET_GH_TOKEN length: ${#LUNAR_SECRET_GH_TOKEN}" >&2
-
 # Only process GitHub repositories
 if [[ ! "$LUNAR_COMPONENT_ID" =~ ^github\.com/ ]]; then
-  echo "[DEBUG] LUNAR_COMPONENT_ID does not match ^github.com/ — exiting 0" >&2
+  echo "Skipping: LUNAR_COMPONENT_ID='${LUNAR_COMPONENT_ID:-<unset>}' is not a GitHub repository" >&2
   exit 0
 fi
-echo "[DEBUG] Component ID matches github.com pattern" >&2
 
 # Check for required environment variables
 if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
-  echo "[DEBUG] LUNAR_SECRET_GH_TOKEN is empty — exiting 1" >&2
-  echo "Error: LUNAR_SECRET_GH_TOKEN is not set" >&2
+  echo "Error: LUNAR_SECRET_GH_TOKEN is not set. Configure the GH_TOKEN secret for this collector." >&2
   exit 1
 fi
 
 if [ -z "$LUNAR_COMPONENT_ID" ]; then
-  echo "[DEBUG] LUNAR_COMPONENT_ID is empty — exiting 1" >&2
   echo "Error: LUNAR_COMPONENT_ID is not set" >&2
   exit 1
 fi
@@ -31,7 +23,6 @@ fi
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)
 REPO=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f3)
-echo "[DEBUG] Parsed OWNER=$OWNER REPO=$REPO" >&2
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Error: Could not parse LUNAR_COMPONENT_ID='$LUNAR_COMPONENT_ID' (expected format: github.com/owner/repo)" >&2
@@ -50,30 +41,14 @@ gh_api() {
   local all_data="[]"
   local page=1
 
-  echo "[DEBUG] gh_api (paginated): starting GET $url" >&2
-
   while true; do
-    local full_url="${url}?per_page=100&page=${page}"
-    echo "[DEBUG] gh_api: GET $full_url" >&2
-
-    local response
-    local http_code
-    response=$(curl -sSL -w "\n%{http_code}" -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
+    local response=$(curl -sSL -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
          -H "Accept: application/vnd.github+json" \
          -H "X-GitHub-Api-Version: 2022-11-28" \
-         "$full_url")
-    http_code=$(echo "$response" | tail -1)
-    response=$(echo "$response" | sed '$d')
-    echo "[DEBUG] gh_api: HTTP $http_code (response length: ${#response})" >&2
-
-    if [ "$http_code" -ge 400 ] 2>/dev/null; then
-      echo "[DEBUG] gh_api: ERROR response: $(echo "$response" | head -c 500)" >&2
-      break
-    fi
+         "${url}?per_page=100&page=${page}")
 
     # Check if response is an array and not empty
     local item_count=$(echo "$response" | jq 'if type == "array" then length else 0 end')
-    echo "[DEBUG] gh_api: page $page returned $item_count items" >&2
 
     if [ "$item_count" -eq 0 ]; then
       break
@@ -89,11 +64,10 @@ gh_api() {
     page=$((page + 1))
   done
 
-  echo "[DEBUG] gh_api: total items collected: $(echo "$all_data" | jq length)" >&2
   echo "$all_data"
 }
 
-echo "[DEBUG] Fetching collaborators for ${OWNER}/${REPO}" >&2
+# Fetch direct collaborators
 COLLABORATORS_DATA=$(gh_api "/repos/${OWNER}/${REPO}/collaborators")
 
 # Extract collaborator information (login and permissions)
@@ -109,9 +83,8 @@ COLLABORATORS=$(echo "$COLLABORATORS_DATA" | jq '[.[] | {
     end,
   type: .type
 }]')
-echo "[DEBUG] Parsed $(echo "$COLLABORATORS" | jq length) collaborators" >&2
 
-echo "[DEBUG] Fetching teams for ${OWNER}/${REPO}" >&2
+# Fetch teams with access
 TEAMS_DATA=$(gh_api "/repos/${OWNER}/${REPO}/teams")
 
 # Extract team information (slug and permission)
@@ -120,10 +93,7 @@ TEAMS=$(echo "$TEAMS_DATA" | jq '[.[] | {
   name: .name,
   permission: .permission
 }]')
-echo "[DEBUG] Parsed $(echo "$TEAMS" | jq length) teams" >&2
 
-echo "[DEBUG] Collecting access permissions data..." >&2
+# Collect access permissions using dot notation
 echo "$COLLABORATORS" | lunar collect -j ".vcs.access.collaborators" -
 echo "$TEAMS" | lunar collect -j ".vcs.access.teams" -
-
-echo "[DEBUG] access_permissions.sh completed successfully" >&2

--- a/collectors/github/branch_protection.sh
+++ b/collectors/github/branch_protection.sh
@@ -14,11 +14,6 @@ if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
   exit 1
 fi
 
-if [ -z "$LUNAR_COMPONENT_ID" ]; then
-  echo "Error: LUNAR_COMPONENT_ID is not set" >&2
-  exit 1
-fi
-
 # LUNAR_COMPONENT_ID should be in format "github.com/owner/repo"
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)

--- a/collectors/github/branch_protection.sh
+++ b/collectors/github/branch_protection.sh
@@ -2,18 +2,27 @@
 
 set -e
 
+echo "[DEBUG] branch_protection.sh starting" >&2
+echo "[DEBUG] LUNAR_COMPONENT_ID=${LUNAR_COMPONENT_ID:-<unset>}" >&2
+echo "[DEBUG] LUNAR_SECRET_GH_TOKEN set: $([ -n "$LUNAR_SECRET_GH_TOKEN" ] && echo 'yes' || echo 'no')" >&2
+echo "[DEBUG] LUNAR_SECRET_GH_TOKEN length: ${#LUNAR_SECRET_GH_TOKEN}" >&2
+
 # Only process GitHub repositories
 if [[ ! "$LUNAR_COMPONENT_ID" =~ ^github\.com/ ]]; then
+  echo "[DEBUG] LUNAR_COMPONENT_ID does not match ^github.com/ — exiting 0" >&2
   exit 0
 fi
+echo "[DEBUG] Component ID matches github.com pattern" >&2
 
 # Check for required environment variables
 if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
+  echo "[DEBUG] LUNAR_SECRET_GH_TOKEN is empty — exiting 1" >&2
   echo "Error: LUNAR_SECRET_GH_TOKEN is not set" >&2
   exit 1
 fi
 
 if [ -z "$LUNAR_COMPONENT_ID" ]; then
+  echo "[DEBUG] LUNAR_COMPONENT_ID is empty — exiting 1" >&2
   echo "Error: LUNAR_COMPONENT_ID is not set" >&2
   exit 1
 fi
@@ -22,6 +31,7 @@ fi
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)
 REPO=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f3)
+echo "[DEBUG] Parsed OWNER=$OWNER REPO=$REPO" >&2
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Error: Could not parse LUNAR_COMPONENT_ID='$LUNAR_COMPONENT_ID' (expected format: github.com/owner/repo)" >&2
@@ -37,29 +47,48 @@ API_BASE="https://api.github.com"
 gh_api() {
   local endpoint="$1"
   local url="${API_BASE}${endpoint}"
+  echo "[DEBUG] gh_api: GET $url" >&2
 
-  curl -sSL -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
+  local http_code
+  local response
+  response=$(curl -sSL -w "\n%{http_code}" -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
        -H "Accept: application/vnd.github+json" \
        -H "X-GitHub-Api-Version: 2022-11-28" \
-       "$url"
+       "$url")
+  http_code=$(echo "$response" | tail -1)
+  response=$(echo "$response" | sed '$d')
+  echo "[DEBUG] gh_api: HTTP $http_code (response length: ${#response})" >&2
+
+  if [ "$http_code" -ge 400 ] 2>/dev/null; then
+    echo "[DEBUG] gh_api: ERROR response: $(echo "$response" | head -c 500)" >&2
+  fi
+
+  echo "$response"
 }
 
 # Get the default branch from the repository
+echo "[DEBUG] Fetching repo data for ${OWNER}/${REPO}" >&2
 REPO_DATA=$(gh_api "/repos/${OWNER}/${REPO}")
 DEFAULT_BRANCH=$(echo "$REPO_DATA" | jq -r '.default_branch')
+echo "[DEBUG] Default branch: $DEFAULT_BRANCH" >&2
 
 # Fetch branch protection settings
-# Note: This endpoint returns 404 if branch protection is not enabled
+echo "[DEBUG] Fetching branch protection for branch '$DEFAULT_BRANCH'" >&2
 PROTECTION_DATA=$(gh_api "/repos/${OWNER}/${REPO}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null || echo '{}')
+echo "[DEBUG] Protection response length: ${#PROTECTION_DATA}" >&2
+echo "[DEBUG] Protection message: $(echo "$PROTECTION_DATA" | jq -r '.message // "none"')" >&2
 
 # Check if branch protection is enabled
 if echo "$PROTECTION_DATA" | jq -e '.message == "Branch not protected"' > /dev/null 2>&1 || \
    echo "$PROTECTION_DATA" | jq -e 'has("message") and .message != null' > /dev/null 2>&1; then
-  # Collect minimal branch protection data
+  echo "[DEBUG] Branch protection not enabled, collecting minimal data" >&2
   lunar collect -j ".vcs.branch_protection.enabled" false
   lunar collect ".vcs.branch_protection.branch" "$DEFAULT_BRANCH"
+  echo "[DEBUG] branch_protection.sh completed (not protected)" >&2
   exit 0
 fi
+
+echo "[DEBUG] Branch protection IS enabled, extracting details..." >&2
 
 # Extract branch protection details
 REQUIRE_PR=$(echo "$PROTECTION_DATA" | jq 'has("required_pull_request_reviews")')
@@ -73,6 +102,7 @@ else
   REQUIRE_CODEOWNER_REVIEW=false
   DISMISS_STALE_REVIEWS=false
 fi
+echo "[DEBUG] PR: require=$REQUIRE_PR approvals=$REQUIRED_APPROVALS codeowner=$REQUIRE_CODEOWNER_REVIEW stale=$DISMISS_STALE_REVIEWS" >&2
 
 # Status checks
 REQUIRE_STATUS_CHECKS=$(echo "$PROTECTION_DATA" | jq 'has("required_status_checks") and .required_status_checks != null')
@@ -83,6 +113,7 @@ else
   REQUIRED_CHECKS='[]'
   REQUIRE_BRANCHES_UP_TO_DATE=false
 fi
+echo "[DEBUG] Status checks: require=$REQUIRE_STATUS_CHECKS checks=$REQUIRED_CHECKS up_to_date=$REQUIRE_BRANCHES_UP_TO_DATE" >&2
 
 # Force push and deletion restrictions
 ALLOW_FORCE_PUSH=$(echo "$PROTECTION_DATA" | jq '.allow_force_pushes.enabled // false')
@@ -104,6 +135,7 @@ else
   RESTRICTIONS_APPS='[]'
 fi
 
+echo "[DEBUG] Collecting branch protection data..." >&2
 # Collect branch protection data using dot notation
 lunar collect -j ".vcs.branch_protection.enabled" true \
       ".vcs.branch_protection.require_pr" "$REQUIRE_PR" \
@@ -123,3 +155,5 @@ echo "$RESTRICTIONS_USERS" | lunar collect -j ".vcs.branch_protection.restrictio
 echo "$RESTRICTIONS_TEAMS" | lunar collect -j ".vcs.branch_protection.restrictions.teams" -
 echo "$RESTRICTIONS_APPS" | lunar collect -j ".vcs.branch_protection.restrictions.apps" -
 echo "$REQUIRED_CHECKS" | lunar collect -j ".vcs.branch_protection.required_checks" -
+
+echo "[DEBUG] branch_protection.sh completed successfully" >&2

--- a/collectors/github/branch_protection.sh
+++ b/collectors/github/branch_protection.sh
@@ -2,27 +2,19 @@
 
 set -e
 
-echo "[DEBUG] branch_protection.sh starting" >&2
-echo "[DEBUG] LUNAR_COMPONENT_ID=${LUNAR_COMPONENT_ID:-<unset>}" >&2
-echo "[DEBUG] LUNAR_SECRET_GH_TOKEN set: $([ -n "$LUNAR_SECRET_GH_TOKEN" ] && echo 'yes' || echo 'no')" >&2
-echo "[DEBUG] LUNAR_SECRET_GH_TOKEN length: ${#LUNAR_SECRET_GH_TOKEN}" >&2
-
 # Only process GitHub repositories
 if [[ ! "$LUNAR_COMPONENT_ID" =~ ^github\.com/ ]]; then
-  echo "[DEBUG] LUNAR_COMPONENT_ID does not match ^github.com/ — exiting 0" >&2
+  echo "Skipping: LUNAR_COMPONENT_ID='${LUNAR_COMPONENT_ID:-<unset>}' is not a GitHub repository" >&2
   exit 0
 fi
-echo "[DEBUG] Component ID matches github.com pattern" >&2
 
 # Check for required environment variables
 if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
-  echo "[DEBUG] LUNAR_SECRET_GH_TOKEN is empty — exiting 1" >&2
-  echo "Error: LUNAR_SECRET_GH_TOKEN is not set" >&2
+  echo "Error: LUNAR_SECRET_GH_TOKEN is not set. Configure the GH_TOKEN secret for this collector." >&2
   exit 1
 fi
 
 if [ -z "$LUNAR_COMPONENT_ID" ]; then
-  echo "[DEBUG] LUNAR_COMPONENT_ID is empty — exiting 1" >&2
   echo "Error: LUNAR_COMPONENT_ID is not set" >&2
   exit 1
 fi
@@ -31,7 +23,6 @@ fi
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)
 REPO=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f3)
-echo "[DEBUG] Parsed OWNER=$OWNER REPO=$REPO" >&2
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Error: Could not parse LUNAR_COMPONENT_ID='$LUNAR_COMPONENT_ID' (expected format: github.com/owner/repo)" >&2
@@ -47,48 +38,29 @@ API_BASE="https://api.github.com"
 gh_api() {
   local endpoint="$1"
   local url="${API_BASE}${endpoint}"
-  echo "[DEBUG] gh_api: GET $url" >&2
 
-  local http_code
-  local response
-  response=$(curl -sSL -w "\n%{http_code}" -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
+  curl -sSL -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
        -H "Accept: application/vnd.github+json" \
        -H "X-GitHub-Api-Version: 2022-11-28" \
-       "$url")
-  http_code=$(echo "$response" | tail -1)
-  response=$(echo "$response" | sed '$d')
-  echo "[DEBUG] gh_api: HTTP $http_code (response length: ${#response})" >&2
-
-  if [ "$http_code" -ge 400 ] 2>/dev/null; then
-    echo "[DEBUG] gh_api: ERROR response: $(echo "$response" | head -c 500)" >&2
-  fi
-
-  echo "$response"
+       "$url"
 }
 
 # Get the default branch from the repository
-echo "[DEBUG] Fetching repo data for ${OWNER}/${REPO}" >&2
 REPO_DATA=$(gh_api "/repos/${OWNER}/${REPO}")
 DEFAULT_BRANCH=$(echo "$REPO_DATA" | jq -r '.default_branch')
-echo "[DEBUG] Default branch: $DEFAULT_BRANCH" >&2
 
 # Fetch branch protection settings
-echo "[DEBUG] Fetching branch protection for branch '$DEFAULT_BRANCH'" >&2
+# Note: This endpoint returns 404 if branch protection is not enabled
 PROTECTION_DATA=$(gh_api "/repos/${OWNER}/${REPO}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null || echo '{}')
-echo "[DEBUG] Protection response length: ${#PROTECTION_DATA}" >&2
-echo "[DEBUG] Protection message: $(echo "$PROTECTION_DATA" | jq -r '.message // "none"')" >&2
 
 # Check if branch protection is enabled
 if echo "$PROTECTION_DATA" | jq -e '.message == "Branch not protected"' > /dev/null 2>&1 || \
    echo "$PROTECTION_DATA" | jq -e 'has("message") and .message != null' > /dev/null 2>&1; then
-  echo "[DEBUG] Branch protection not enabled, collecting minimal data" >&2
+  # Collect minimal branch protection data
   lunar collect -j ".vcs.branch_protection.enabled" false
   lunar collect ".vcs.branch_protection.branch" "$DEFAULT_BRANCH"
-  echo "[DEBUG] branch_protection.sh completed (not protected)" >&2
   exit 0
 fi
-
-echo "[DEBUG] Branch protection IS enabled, extracting details..." >&2
 
 # Extract branch protection details
 REQUIRE_PR=$(echo "$PROTECTION_DATA" | jq 'has("required_pull_request_reviews")')
@@ -102,7 +74,6 @@ else
   REQUIRE_CODEOWNER_REVIEW=false
   DISMISS_STALE_REVIEWS=false
 fi
-echo "[DEBUG] PR: require=$REQUIRE_PR approvals=$REQUIRED_APPROVALS codeowner=$REQUIRE_CODEOWNER_REVIEW stale=$DISMISS_STALE_REVIEWS" >&2
 
 # Status checks
 REQUIRE_STATUS_CHECKS=$(echo "$PROTECTION_DATA" | jq 'has("required_status_checks") and .required_status_checks != null')
@@ -113,7 +84,6 @@ else
   REQUIRED_CHECKS='[]'
   REQUIRE_BRANCHES_UP_TO_DATE=false
 fi
-echo "[DEBUG] Status checks: require=$REQUIRE_STATUS_CHECKS checks=$REQUIRED_CHECKS up_to_date=$REQUIRE_BRANCHES_UP_TO_DATE" >&2
 
 # Force push and deletion restrictions
 ALLOW_FORCE_PUSH=$(echo "$PROTECTION_DATA" | jq '.allow_force_pushes.enabled // false')
@@ -135,7 +105,6 @@ else
   RESTRICTIONS_APPS='[]'
 fi
 
-echo "[DEBUG] Collecting branch protection data..." >&2
 # Collect branch protection data using dot notation
 lunar collect -j ".vcs.branch_protection.enabled" true \
       ".vcs.branch_protection.require_pr" "$REQUIRE_PR" \
@@ -155,5 +124,3 @@ echo "$RESTRICTIONS_USERS" | lunar collect -j ".vcs.branch_protection.restrictio
 echo "$RESTRICTIONS_TEAMS" | lunar collect -j ".vcs.branch_protection.restrictions.teams" -
 echo "$RESTRICTIONS_APPS" | lunar collect -j ".vcs.branch_protection.restrictions.apps" -
 echo "$REQUIRED_CHECKS" | lunar collect -j ".vcs.branch_protection.required_checks" -
-
-echo "[DEBUG] branch_protection.sh completed successfully" >&2

--- a/collectors/github/repository.sh
+++ b/collectors/github/repository.sh
@@ -14,11 +14,6 @@ if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
   exit 1
 fi
 
-if [ -z "$LUNAR_COMPONENT_ID" ]; then
-  echo "Error: LUNAR_COMPONENT_ID is not set" >&2
-  exit 1
-fi
-
 # LUNAR_COMPONENT_ID should be in format "github.com/owner/repo"
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)

--- a/collectors/github/repository.sh
+++ b/collectors/github/repository.sh
@@ -2,18 +2,27 @@
 
 set -e
 
+echo "[DEBUG] repository.sh starting" >&2
+echo "[DEBUG] LUNAR_COMPONENT_ID=${LUNAR_COMPONENT_ID:-<unset>}" >&2
+echo "[DEBUG] LUNAR_SECRET_GH_TOKEN set: $([ -n "$LUNAR_SECRET_GH_TOKEN" ] && echo 'yes' || echo 'no')" >&2
+echo "[DEBUG] LUNAR_SECRET_GH_TOKEN length: ${#LUNAR_SECRET_GH_TOKEN}" >&2
+
 # Only process GitHub repositories
 if [[ ! "$LUNAR_COMPONENT_ID" =~ ^github\.com/ ]]; then
+  echo "[DEBUG] LUNAR_COMPONENT_ID does not match ^github.com/ — exiting 0" >&2
   exit 0
 fi
+echo "[DEBUG] Component ID matches github.com pattern" >&2
 
 # Check for required environment variables
 if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
+  echo "[DEBUG] LUNAR_SECRET_GH_TOKEN is empty — exiting 1" >&2
   echo "Error: LUNAR_SECRET_GH_TOKEN is not set" >&2
   exit 1
 fi
 
 if [ -z "$LUNAR_COMPONENT_ID" ]; then
+  echo "[DEBUG] LUNAR_COMPONENT_ID is empty — exiting 1" >&2
   echo "Error: LUNAR_COMPONENT_ID is not set" >&2
   exit 1
 fi
@@ -22,6 +31,7 @@ fi
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)
 REPO=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f3)
+echo "[DEBUG] Parsed OWNER=$OWNER REPO=$REPO" >&2
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Error: Could not parse LUNAR_COMPONENT_ID='$LUNAR_COMPONENT_ID' (expected format: github.com/owner/repo)" >&2
@@ -37,14 +47,26 @@ API_BASE="https://api.github.com"
 gh_api() {
   local endpoint="$1"
   local url="${API_BASE}${endpoint}"
+  echo "[DEBUG] gh_api: GET $url" >&2
 
-  curl -sSL -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
+  local http_code
+  local response
+  response=$(curl -sSL -w "\n%{http_code}" -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
        -H "Accept: application/vnd.github+json" \
        -H "X-GitHub-Api-Version: 2022-11-28" \
-       "$url"
+       "$url")
+  http_code=$(echo "$response" | tail -1)
+  response=$(echo "$response" | sed '$d')
+  echo "[DEBUG] gh_api: HTTP $http_code (response length: ${#response})" >&2
+
+  if [ "$http_code" -ge 400 ] 2>/dev/null; then
+    echo "[DEBUG] gh_api: ERROR response: $(echo "$response" | head -c 500)" >&2
+  fi
+
+  echo "$response"
 }
 
-# Fetch repository information
+echo "[DEBUG] Fetching repo data for ${OWNER}/${REPO}" >&2
 REPO_DATA=$(gh_api "/repos/${OWNER}/${REPO}")
 
 # Extract basic repository settings
@@ -55,6 +77,10 @@ ALLOW_MERGE_COMMIT=$(echo "$REPO_DATA" | jq '.allow_merge_commit')
 ALLOW_SQUASH_MERGE=$(echo "$REPO_DATA" | jq '.allow_squash_merge')
 ALLOW_REBASE_MERGE=$(echo "$REPO_DATA" | jq '.allow_rebase_merge')
 
+echo "[DEBUG] Parsed: default_branch=$DEFAULT_BRANCH visibility=$VISIBILITY topics=$TOPICS" >&2
+echo "[DEBUG] Merge strategies: commit=$ALLOW_MERGE_COMMIT squash=$ALLOW_SQUASH_MERGE rebase=$ALLOW_REBASE_MERGE" >&2
+
+echo "[DEBUG] Collecting VCS data..." >&2
 # Collect provider (string)
 lunar collect ".vcs.provider" "github" \
       ".vcs.default_branch" "$DEFAULT_BRANCH" \
@@ -68,3 +94,5 @@ lunar collect -j \
       ".vcs.merge_strategies.allow_merge_commit" "$ALLOW_MERGE_COMMIT" \
       ".vcs.merge_strategies.allow_squash_merge" "$ALLOW_SQUASH_MERGE" \
       ".vcs.merge_strategies.allow_rebase_merge" "$ALLOW_REBASE_MERGE"
+
+echo "[DEBUG] repository.sh completed successfully" >&2

--- a/collectors/github/repository.sh
+++ b/collectors/github/repository.sh
@@ -2,27 +2,19 @@
 
 set -e
 
-echo "[DEBUG] repository.sh starting" >&2
-echo "[DEBUG] LUNAR_COMPONENT_ID=${LUNAR_COMPONENT_ID:-<unset>}" >&2
-echo "[DEBUG] LUNAR_SECRET_GH_TOKEN set: $([ -n "$LUNAR_SECRET_GH_TOKEN" ] && echo 'yes' || echo 'no')" >&2
-echo "[DEBUG] LUNAR_SECRET_GH_TOKEN length: ${#LUNAR_SECRET_GH_TOKEN}" >&2
-
 # Only process GitHub repositories
 if [[ ! "$LUNAR_COMPONENT_ID" =~ ^github\.com/ ]]; then
-  echo "[DEBUG] LUNAR_COMPONENT_ID does not match ^github.com/ — exiting 0" >&2
+  echo "Skipping: LUNAR_COMPONENT_ID='${LUNAR_COMPONENT_ID:-<unset>}' is not a GitHub repository" >&2
   exit 0
 fi
-echo "[DEBUG] Component ID matches github.com pattern" >&2
 
 # Check for required environment variables
 if [ -z "$LUNAR_SECRET_GH_TOKEN" ]; then
-  echo "[DEBUG] LUNAR_SECRET_GH_TOKEN is empty — exiting 1" >&2
-  echo "Error: LUNAR_SECRET_GH_TOKEN is not set" >&2
+  echo "Error: LUNAR_SECRET_GH_TOKEN is not set. Configure the GH_TOKEN secret for this collector." >&2
   exit 1
 fi
 
 if [ -z "$LUNAR_COMPONENT_ID" ]; then
-  echo "[DEBUG] LUNAR_COMPONENT_ID is empty — exiting 1" >&2
   echo "Error: LUNAR_COMPONENT_ID is not set" >&2
   exit 1
 fi
@@ -31,7 +23,6 @@ fi
 # Extract owner and repo from LUNAR_COMPONENT_ID
 OWNER=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f2)
 REPO=$(echo "$LUNAR_COMPONENT_ID" | cut -d'/' -f3)
-echo "[DEBUG] Parsed OWNER=$OWNER REPO=$REPO" >&2
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Error: Could not parse LUNAR_COMPONENT_ID='$LUNAR_COMPONENT_ID' (expected format: github.com/owner/repo)" >&2
@@ -47,26 +38,14 @@ API_BASE="https://api.github.com"
 gh_api() {
   local endpoint="$1"
   local url="${API_BASE}${endpoint}"
-  echo "[DEBUG] gh_api: GET $url" >&2
 
-  local http_code
-  local response
-  response=$(curl -sSL -w "\n%{http_code}" -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
+  curl -sSL -H "Authorization: token ${LUNAR_SECRET_GH_TOKEN}" \
        -H "Accept: application/vnd.github+json" \
        -H "X-GitHub-Api-Version: 2022-11-28" \
-       "$url")
-  http_code=$(echo "$response" | tail -1)
-  response=$(echo "$response" | sed '$d')
-  echo "[DEBUG] gh_api: HTTP $http_code (response length: ${#response})" >&2
-
-  if [ "$http_code" -ge 400 ] 2>/dev/null; then
-    echo "[DEBUG] gh_api: ERROR response: $(echo "$response" | head -c 500)" >&2
-  fi
-
-  echo "$response"
+       "$url"
 }
 
-echo "[DEBUG] Fetching repo data for ${OWNER}/${REPO}" >&2
+# Fetch repository information
 REPO_DATA=$(gh_api "/repos/${OWNER}/${REPO}")
 
 # Extract basic repository settings
@@ -77,10 +56,6 @@ ALLOW_MERGE_COMMIT=$(echo "$REPO_DATA" | jq '.allow_merge_commit')
 ALLOW_SQUASH_MERGE=$(echo "$REPO_DATA" | jq '.allow_squash_merge')
 ALLOW_REBASE_MERGE=$(echo "$REPO_DATA" | jq '.allow_rebase_merge')
 
-echo "[DEBUG] Parsed: default_branch=$DEFAULT_BRANCH visibility=$VISIBILITY topics=$TOPICS" >&2
-echo "[DEBUG] Merge strategies: commit=$ALLOW_MERGE_COMMIT squash=$ALLOW_SQUASH_MERGE rebase=$ALLOW_REBASE_MERGE" >&2
-
-echo "[DEBUG] Collecting VCS data..." >&2
 # Collect provider (string)
 lunar collect ".vcs.provider" "github" \
       ".vcs.default_branch" "$DEFAULT_BRANCH" \
@@ -94,5 +69,3 @@ lunar collect -j \
       ".vcs.merge_strategies.allow_merge_commit" "$ALLOW_MERGE_COMMIT" \
       ".vcs.merge_strategies.allow_squash_merge" "$ALLOW_SQUASH_MERGE" \
       ".vcs.merge_strategies.allow_rebase_merge" "$ALLOW_REBASE_MERGE"
-
-echo "[DEBUG] repository.sh completed successfully" >&2

--- a/policies/vcs/allowed-merge-strategies.py
+++ b/policies/vcs/allowed-merge-strategies.py
@@ -4,9 +4,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None, allowed_strategies_override=None):
     c = Check("allowed-merge-strategies", "Merge strategies should match allowed list", node=node)
     with c:
-        c.assert_exists(".vcs.merge_strategies", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.merge_strategies").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         allowed_merge_strategies = allowed_strategies_override if allowed_strategies_override is not None else variable_or_default("allowed_merge_strategies", "")
         allowed_list = [s.strip().lower() for s in allowed_merge_strategies.split(",") if s.strip()]
 

--- a/policies/vcs/allowed-merge-strategies.py
+++ b/policies/vcs/allowed-merge-strategies.py
@@ -6,6 +6,7 @@ def main(node=None, allowed_strategies_override=None):
     with c:
         if not c.get_node(".vcs.merge_strategies").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         allowed_merge_strategies = allowed_strategies_override if allowed_strategies_override is not None else variable_or_default("allowed_merge_strategies", "")
         allowed_list = [s.strip().lower() for s in allowed_merge_strategies.split(",") if s.strip()]

--- a/policies/vcs/branch-protection-enabled.py
+++ b/policies/vcs/branch-protection-enabled.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("branch-protection-enabled", "Branch protection should be enabled", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         branch = c.get_value_or_default(".vcs.branch_protection.branch", "default branch")
 

--- a/policies/vcs/branch-protection-enabled.py
+++ b/policies/vcs/branch-protection-enabled.py
@@ -6,6 +6,7 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         branch = c.get_value_or_default(".vcs.branch_protection.branch", "default branch")

--- a/policies/vcs/disallow-branch-deletion.py
+++ b/policies/vcs/disallow-branch-deletion.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("disallow-branch-deletion", "Branch deletions should be disallowed", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/disallow-branch-deletion.py
+++ b/policies/vcs/disallow-branch-deletion.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             allow_deletions = c.get_value(".vcs.branch_protection.allow_deletions")
             c.assert_false(allow_deletions, "Branch protection allows branch deletion, but policy requires it to be disabled")

--- a/policies/vcs/disallow-force-push.py
+++ b/policies/vcs/disallow-force-push.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("disallow-force-push", "Force pushes should be disallowed", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/disallow-force-push.py
+++ b/policies/vcs/disallow-force-push.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             allow_force_push = c.get_value(".vcs.branch_protection.allow_force_push")
             c.assert_false(allow_force_push, "Branch protection allows force pushes, but policy requires them to be disabled")

--- a/policies/vcs/dismiss-stale-reviews.py
+++ b/policies/vcs/dismiss-stale-reviews.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             dismiss_stale_reviews = c.get_value(".vcs.branch_protection.dismiss_stale_reviews")
             c.assert_true(dismiss_stale_reviews, "Branch protection does not dismiss stale reviews when new commits are pushed")

--- a/policies/vcs/dismiss-stale-reviews.py
+++ b/policies/vcs/dismiss-stale-reviews.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("dismiss-stale-reviews", "Stale reviews should be dismissed", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/minimum-approvals.py
+++ b/policies/vcs/minimum-approvals.py
@@ -6,10 +6,12 @@ def main(node=None, min_approvals_override=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             min_approvals = min_approvals_override if min_approvals_override is not None else variable_or_default("min_approvals", None)
             if min_approvals is None:

--- a/policies/vcs/minimum-approvals.py
+++ b/policies/vcs/minimum-approvals.py
@@ -4,9 +4,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None, min_approvals_override=None):
     c = Check("minimum-approvals", "Pull requests should require minimum number of approvals", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/require-branches-up-to-date.py
+++ b/policies/vcs/require-branches-up-to-date.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-branches-up-to-date", "Branches should be required to be up to date", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/require-branches-up-to-date.py
+++ b/policies/vcs/require-branches-up-to-date.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             require_branches_up_to_date = c.get_value(".vcs.branch_protection.require_branches_up_to_date")
             c.assert_true(require_branches_up_to_date, "Branch protection does not require branches to be up to date before merging")

--- a/policies/vcs/require-codeowner-review.py
+++ b/policies/vcs/require-codeowner-review.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-codeowner-review", "Code owner review should be required", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/require-codeowner-review.py
+++ b/policies/vcs/require-codeowner-review.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             require_codeowner_review = c.get_value(".vcs.branch_protection.require_codeowner_review")
             c.assert_true(require_codeowner_review, "Branch protection does not require code owner review")

--- a/policies/vcs/require-default-branch.py
+++ b/policies/vcs/require-default-branch.py
@@ -6,6 +6,7 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         required_default_branch = variable_or_default("required_default_branch", "main")
         default_branch = c.get_value(".vcs.default_branch")

--- a/policies/vcs/require-default-branch.py
+++ b/policies/vcs/require-default-branch.py
@@ -4,9 +4,9 @@ from lunar_policy import Check, variable_or_default
 def main(node=None):
     c = Check("require-default-branch", "Default branch should match required name", node=node)
     with c:
-        c.assert_exists(".vcs.default_branch", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         required_default_branch = variable_or_default("required_default_branch", "main")
         default_branch = c.get_value(".vcs.default_branch")
 

--- a/policies/vcs/require-linear-history.py
+++ b/policies/vcs/require-linear-history.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-linear-history", "Linear history should be required", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/require-linear-history.py
+++ b/policies/vcs/require-linear-history.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             require_linear_history = c.get_value(".vcs.branch_protection.require_linear_history")
             c.assert_true(require_linear_history, "Branch protection does not require linear history")

--- a/policies/vcs/require-private.py
+++ b/policies/vcs/require-private.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-private", "Repository must be private", node=node)
     with c:
-        c.assert_exists(".vcs.visibility", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         visibility = c.get_value(".vcs.visibility")
         c.assert_equals(visibility, "private", f"Repository visibility is '{visibility}', but policy requires 'private'")
     return c

--- a/policies/vcs/require-private.py
+++ b/policies/vcs/require-private.py
@@ -6,6 +6,7 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         visibility = c.get_value(".vcs.visibility")
         c.assert_equals(visibility, "private", f"Repository visibility is '{visibility}', but policy requires 'private'")

--- a/policies/vcs/require-pull-request.py
+++ b/policies/vcs/require-pull-request.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             require_pr = c.get_value(".vcs.branch_protection.require_pr")
             c.assert_true(require_pr, "Branch protection does not require pull requests before merging")

--- a/policies/vcs/require-pull-request.py
+++ b/policies/vcs/require-pull-request.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-pull-request", "Pull requests should be required", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/require-signed-commits.py
+++ b/policies/vcs/require-signed-commits.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             require_signed_commits = c.get_value(".vcs.branch_protection.require_signed_commits")
             c.assert_true(require_signed_commits, "Branch protection does not require signed commits")

--- a/policies/vcs/require-signed-commits.py
+++ b/policies/vcs/require-signed-commits.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-signed-commits", "Signed commits should be required", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")

--- a/policies/vcs/require-status-checks.py
+++ b/policies/vcs/require-status-checks.py
@@ -6,10 +6,12 @@ def main(node=None):
     with c:
         if not c.get_node(".vcs.branch_protection").exists():
             c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+            return c
 
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")
+            return c
         else:
             require_status_checks = c.get_value(".vcs.branch_protection.require_status_checks")
             c.assert_true(require_status_checks, "Branch protection does not require status checks to pass")

--- a/policies/vcs/require-status-checks.py
+++ b/policies/vcs/require-status-checks.py
@@ -4,9 +4,9 @@ from lunar_policy import Check
 def main(node=None):
     c = Check("require-status-checks", "Status checks should be required", node=node)
     with c:
-        c.assert_exists(".vcs.branch_protection", 
-            "VCS data not found. Ensure the github collector is configured and has run.")
-        
+        if not c.get_node(".vcs.branch_protection").exists():
+            c.fail("VCS data not found. Ensure the github collector is configured and has run.")
+
         enabled = c.get_value(".vcs.branch_protection.enabled")
         if not enabled:
             c.fail("Branch protection is not enabled")


### PR DESCRIPTION
## Summary

Two fixes discovered while debugging missing VCS data on cronos:

**GitHub collector** (`collectors/github/`):
- Add informative log messages when the collector skips (non-GitHub component) or errors (missing secret), so silent exit-0 runs are diagnosable from run logs
- No functional changes to collection logic

**VCS policies** (`policies/vcs/`):
- Replace `assert_exists()` with `get_node().exists()` + explicit `c.fail()` in all 13 VCS policy checks
- `assert_exists()` raises `NoDataError` which keeps the check stuck in `pending`/`no-data` state indefinitely when the GitHub collector never produces `.vcs` data (e.g., due to the Hub component_id bug passing UUID instead of name)
- `get_node().exists()` returns `False` after collectors finish, letting the policy settle at a concrete FAIL with an actionable message

**Root cause context:** The Hub was passing a UUID as `LUNAR_COMPONENT_ID` instead of the component name (`github.com/org/repo`), so the collector's `^github.com/` regex guard caused a silent `exit 0`. That's a separate Hub fix (PR 1304), but the collector and policies should be resilient regardless.

## Test plan

- [ ] Verify `lunar collector dev github.repository --component github.com/pantalasa-cronos/backend` still produces data
- [ ] Verify `lunar policy dev vcs.require-default-branch --component github.com/pantalasa-cronos/backend` returns FAIL (not pending) when .vcs is missing
- [ ] Verify policies return PASS when .vcs data is present