### PR TITLE
Unify .lunar/checks.yml hook vocabulary; add agent-before-command, agent-before-tool-call, agent-after-file-edit-nudge

### DIFF
--- a/.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md
+++ b/.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md
@@ -178,11 +178,24 @@ When the primary reviewer is satisfied, they will assign a **secondary reviewer*
 - If reviewers are discussing with each other (e.g. @-mentioning each other), **wait for them to reach a conclusion** before acting.
 - They may address you as "claude" or "devin" or "bender" in PR comments — treat that as a direct instruction.
 
-**When the secondary reviewer approves: start implementing immediately.** Their approval is the "go ahead" signal. Do not ask for permission or confirmation — begin Step 1 of the implementation checklist below.
+**When the secondary reviewer approves: start implementing immediately.** Their approval is the "go ahead" signal. Do not ask for permission or confirmation — begin the implementation work below.
+
+"Implementing" here means the **whole next unit**, not just writing code: write → push → run CI → **deploy to cronos → test → post evidence on the PR**. All of that happens under your own authority without further human input. The next time you should be "waiting" is after you've posted test evidence (Step 8).
 
 ---
 
 ## Implementation (same PR)
+
+> **Implementation and testing are one unbroken unit.** Do not stop after writing code, pushing, and confirming `+lint` / `+test` / `+all` pass on GitHub. **CI green is not the finish line.** The work is not done until you have also:
+>
+> 1. Deployed the branch to cronos (Step 3 below),
+> 2. Triggered collection against a real component (Step 5),
+> 3. Gathered evidence (Step 7), and
+> 4. Posted that evidence on the PR as a comment (Step 8).
+>
+> All of that happens under your own authority — it does NOT require reviewer approval, reviewer comments, or any human "go ahead." Keep going straight through.
+>
+> You are only "waiting for review" once the PR comment with test evidence is up. If you just wrote implementation code and pushed it, you are nowhere near waiting.
 
 ### What to produce
 
@@ -204,6 +217,10 @@ The actual scripts referenced in the YAML manifest:
 ## Testing
 
 Follow this checklist **in order**. Every step must be completed before moving to the next.
+
+**Start immediately after writing implementation code.** Don't wait for a reviewer to say "please test this" — cronos testing is your responsibility as the implementer, not something that gets triggered by review feedback. The moment you've pushed implementation code and watched `+lint` / `+test` / `+all` pass, go straight to Step 3 (deploy to cronos). You do not need approval to run these steps. If anything, **not** running these steps is the blocker that will make reviewers ask you to come back.
+
+Reviewers expect to see your test evidence on the PR before their review is meaningful. A PR comment with Grafana screenshots + Component JSON output (Step 8) is what unblocks implementation review — not vice versa.
 
 ### Step 1: Write implementation code
 
@@ -576,6 +593,8 @@ Unit tests are not required and should **not** be committed. The primary way to 
 ---
 
 ## Implementation review
+
+> **Precondition: you have posted test evidence on the PR (Step 8).** If you haven't — if you're here because you pushed implementation code and CI went green — you are not ready for this section. Go back to Step 3 and finish the Testing checklist. Implementation review does not start until evidence is posted.
 
 Claude will automatically review the PR via the `claude-code-action` GitHub Action. Address its feedback, but **use judgment** — Claude sometimes flags things that aren't real issues. If a comment is wrong or irrelevant, reply explaining why and resolve the thread. When you've addressed a valid comment (pushed a fix), resolve that thread too. Don't leave conversations hanging.
 

--- a/.lunar/checks.yml
+++ b/.lunar/checks.yml
@@ -1,60 +1,101 @@
+# Agent guardrail hooks for lunar-lib plugin authors.
+#
+# Every entry declares a `hook:` type that determines when it fires. Hook types
+# follow the `<env>-<before|after>-<noun>` convention used by Lunar collector
+# CI hooks (e.g. `ci-before-command`), except with the `agent-` prefix for the
+# agent-sandbox execution environment:
+#
+#   hook:                         When it fires                        Matcher
+#   ----------------------------  -----------------------------------  ---------------------------
+#   agent-session-start           When agent session begins (startup   (none — stdout becomes
+#                                 or resume); content in stdout or      additionalContext for the
+#                                 `message:` injected as extra          whole session)
+#                                 context.
+#   agent-after-file-edit         After agent writes/edits a file,     `on:` (file path glob)
+#                                 run `run:` as a validation. Non-
+#                                 zero exit surfaces `message:`.
+#   agent-after-file-edit-nudge   Like above, but no `run:` — always   `on:` (file path glob);
+#                                 surfaces `message:` when matched.    optional `when:` gate
+#                                 Optional `when:` runs a bash test;   (bash expression, {file}
+#                                 nudge fires only when it exits 0.    substituted)
+#   agent-before-command          Before agent runs a shell cmd        `binary:` (structured)
+#   agent-before-tool-call        Before agent invokes a named tool    `tool:` (framework tool)
+#   agent-session-end             When agent session ends              `on:` (any changed file
+#                                                                       matches the glob)
+#
+# Reserved for future use (schema documented, not yet dispatched by runners):
+#   agent-before-file-edit        Before agent writes/edits a file (can block/modify content)
+#   agent-after-command           After agent runs a shell command
+#   agent-after-tool-call         After agent invokes a named tool
+#   agent-before-prompt           Before agent processes a user prompt
+#
+# See .lunar/hooks/README.md for the full schema, dispatch semantics, and
+# how to contribute new hooks.
+
 checks:
-  # ── Hard validations ──
+  # ── Hard validations (agent-after-file-edit) ──
+  # `run:` is a real test. Non-zero exit surfaces the message to the agent.
 
   - name: svg-black-fill
+    hook: agent-after-file-edit
     on: "**/assets/*.svg"
     run: "grep -qE 'fill=\"black\"' {file} && ! grep -iqE 'fill=\"(white|#fff|#ffffff)\"' {file}"
     message: "SVG must use fill=\"black\". Website converts to white automatically."
 
   - name: svg-no-title-tag
+    hook: agent-after-file-edit
     on: "**/assets/*.svg"
     run: "! grep -qE '<title>' {file}"
     message: "Strip <title> tags from SVG icons. They add unnecessary metadata."
 
-  # ── Stop-phase checks (run once at end of session, not per-file) ──
-  # These use "hook: stop" to run in the Stop hook instead of PostToolUse.
-  # The Stop hook checks if any changed file matches the "on" pattern,
-  # then runs the command once (not per-file). Use for expensive checks.
-
-  - name: lint
-    hook: stop
-    on: "**/*.yml"
-    run: "earthly +lint 2>&1 | tail -10"
-    message: "Linter failed. Fix errors before pushing."
-
   - name: earthfile-wired-into-all
+    hook: agent-after-file-edit
     on: "collectors/*/Earthfile"
     run: "PLUGIN_DIR=$(dirname {file} | sed \"s|$(git rev-parse --show-toplevel)/||\"); ROOT_EF=$(git rev-parse --show-toplevel)/Earthfile; grep -q \"$PLUGIN_DIR\" \"$ROOT_EF\""
     message: "This plugin has an Earthfile but is not referenced in the root Earthfile's +all target. Add: BUILD --pass-args ./<plugin-path>+image"
 
   - name: collector-gnu-grep
+    hook: agent-after-file-edit
     on: "collectors/**/*.sh"
     run: "! grep -nE 'grep\\s+-[a-zA-Z]*P|grep\\s+--include|grep\\s+--perl-regexp' {file}"
     message: "GNU grep extension detected. This runs on Alpine/BusyBox where -P and --include are not available. Use sed, find, or BusyBox-compatible patterns."
 
-  # ── Nudges (exit 1 to surface the message via additionalContext) ──
-  # The hook runner (lunar-verify.sh) collects findings from non-zero exits
-  # and returns them as additionalContext JSON. The hook itself always exits 0,
-  # so nudges never block the agent — they just surface reminders.
+  # ── Session-end checks (agent-session-end) ──
+  # Fire once at the end of a session if any changed file matches `on:`.
+  # Use for expensive validations whose cost doesn't scale with per-file granularity.
+
+  - name: lint
+    hook: agent-session-end
+    on: "**/*.yml"
+    run: "earthly +lint 2>&1 | tail -10"
+    message: "Linter failed. Fix errors before pushing."
+
+  # ── Nudges (agent-after-file-edit-nudge) ──
+  # Reminders shown alongside file edits. No `run:` — the `message:` is the
+  # whole hook. Optional `when:` field gates the nudge on a bash expression
+  # ({file} is substituted with the edited file path); the nudge fires only
+  # when `when:` exits 0.
 
   - name: svg-logo-sourcing
+    hook: agent-after-file-edit-nudge
     on: "**/assets/*.svg"
-    run: "exit 1"
     message: "Reminder: Is this a tech-specific collector or policy? Check simple-icons (https://github.com/simple-icons/simple-icons) for an official logo before creating a custom one."
 
   - name: ci-collector-testing-reminder
+    hook: agent-after-file-edit-nudge
     on: "collectors/*/lunar-collector.yml"
-    run: "if grep -q 'type: ci-' {file}; then exit 1; else exit 0; fi"
+    when: "grep -q 'type: ci-' {file}"
     message: "Reminder: This collector has CI hooks. Local 'lunar collector dev' is NOT sufficient -- you must test on cronos with a real CI run (push config, trigger component build, verify data on hub)."
 
   - name: manifest-example-json-freshness
+    hook: agent-after-file-edit-nudge
     on: "collectors/*/lunar-collector.yml"
-    run: "exit 1"
     message: "Reminder: Does example_component_json still match what the collector actually produces? Run 'lunar collector dev' and compare the output to the example in this manifest."
 
   - name: policy-skip-vs-fail
+    hook: agent-after-file-edit-nudge
     on: "policies/**/*.py"
-    run: "! grep -qE '\\.skip\\s*\\(' {file}"
+    when: "grep -qE '\\.skip\\s*\\(' {file}"
     message: >-
       This policy file contains a .skip() call — is skip appropriate here?
       Rule of thumb: skip = category does not apply to this component
@@ -67,8 +108,8 @@ checks:
       the full decision tree.
 
   - name: screenshot-quality-reminder
+    hook: agent-after-file-edit-nudge
     on: "**/*screenshot*"
-    run: "exit 1"
     message: >-
       Reminder: Screenshots uploaded to PRs must be scrolled to show the
       RELEVANT data, not the default top-of-page view. Dashboard screenshots
@@ -76,3 +117,58 @@ checks:
       JSON screenshots should show the namespace/keys being verified. If the
       data is too large for one screen, capture the section that serves as an
       end-to-end smoke test.
+
+  # ── Agent session-start hooks ──
+  # Fire once when an agent session begins (including `claude -p` headless
+  # resumes). Stdout becomes additionalContext the agent sees before its
+  # first turn. Use for orientation — what phase is this work in? which
+  # playbook section applies? — not for long-running checks.
+
+  - name: phase-guidance
+    hook: agent-session-start
+    run: .lunar/hooks/phase-guidance.sh
+    message: >-
+      Before doing PR work, identify the phase (spec-review /
+      implementing / impl-review / merging) and read the matching
+      section of `.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md`.
+      CI green is not the finish line for implementation PRs —
+      cronos round-trip testing is required.
+
+  # ── Agent before-command hooks ──
+  # Fire before an agent (e.g. Claude Code) executes a shell command in its
+  # sandbox. Hook exits 0 → allow; non-zero → block with stderr shown to the
+  # agent. The runner pipes the PreToolUse JSON payload to `run:` on stdin.
+  # Matcher shape mirrors Lunar collector `ci-before-command` hooks.
+
+  - name: lunar-cli-guard
+    hook: agent-before-command
+    binary:
+      name: lunar
+    run: .lunar/hooks/lunar-cli-guard.sh
+    message: >-
+      Block `lunar` CLI commands when context is wrong:
+      LUNAR_HUB_TOKEN must be set, and commands that talk to the hub
+      (collector|policy|component|catalog|sql|secret|hub) must run from a
+      directory with `lunar-config.yml`. Honours `cd <dir> && lunar ...`
+      prefixes; allows `--help` / `--version` freely.
+
+  # ── Agent before-tool-call hooks ──
+  # Fire before an agent invokes a named tool (any tool, not just shell).
+  # Matcher is the framework's literal tool name — portable in shape but not
+  # in values (ScheduleWakeup is Claude-specific; other frameworks have
+  # different tool names for their scheduling primitives, if any).
+
+  - name: block-schedule-wakeup
+    hook: agent-before-tool-call
+    tool:
+      name: ScheduleWakeup
+    run: "exit 2"
+    message: >-
+      ScheduleWakeup is a no-op in this agent environment — nothing picks up
+      at the scheduled time, so the worker would silently park until the next
+      human nudge. Instead:
+        - For short waits (<2 min): use Monitor, `gh pr checks --watch`, or
+          chained `sleep N && <check>` loops inside the current invocation.
+        - For long waits (CI, sync-manifest, cronos collection cycle):
+          exit and let the next webhook event (CI status, PR comment, etc.)
+          resume the session.

--- a/.lunar/hooks/README.md
+++ b/.lunar/hooks/README.md
@@ -1,0 +1,179 @@
+# `.lunar/hooks/` — Scripts for Agent-Sandbox Hooks
+
+Shell scripts referenced by `.lunar/checks.yml` entries whose logic is too involved for an inline `run:` one-liner. Each script receives a JSON payload on stdin from the agent sandbox (e.g. Claude Code) and returns exit code 0 to allow or non-zero (typically 2) to block/surface a message via stderr.
+
+## `.lunar/checks.yml` is the source of truth
+
+Every hook is declared in `.lunar/checks.yml`. Scripts in this directory are the *implementation* of imperative hooks. A declaration looks like this:
+
+```yaml
+- name: lunar-cli-guard
+  hook: agent-before-command
+  binary:
+    name: lunar
+  run: .lunar/hooks/lunar-cli-guard.sh
+  message: "…"
+```
+
+Prefer inline `run:` for simple hooks and skip this directory entirely.
+
+## Hook type vocabulary
+
+All hook types follow the `<env>-<before|after>-<noun>` convention used by Lunar collector CI hooks (`ci-before-command`, `ci-after-command`, etc), with the `agent-` prefix denoting the agent-sandbox execution environment.
+
+### Implemented in runners today
+
+| `hook:` value | When it fires | Matcher | Framework event |
+|---|---|---|---|
+| `agent-session-start` | At the start of every agent session (fresh or resumed) — stdout/`message:` becomes `additionalContext` for the whole session | (none) | Claude `SessionStart` with `matcher: "startup\|resume"`; Gemini `SessionStart` |
+| `agent-after-file-edit` | After agent writes or edits a file; `run:` is a real validation | `on:` (file path glob) | Claude `PostToolUse` matching `Edit\|Write`; Gemini `AfterTool` matching `write_file\|replace` |
+| `agent-after-file-edit-nudge` | After agent writes or edits a file; surfaces `message:` as an advisory reminder (optionally gated by `when:`) | `on:` (glob) + optional `when:` (bash test) | same as above |
+| `agent-before-command` | Before agent executes a shell command | `binary:` (structured) | Claude/Codex `PreToolUse` matching `Bash`; Gemini `BeforeTool` matching `run_shell_command` |
+| `agent-before-tool-call` | Before agent invokes any named tool | `tool:` (framework tool name) | Claude/Codex `PreToolUse`; Gemini `BeforeTool` |
+| `agent-session-end` | When agent session ends, if any changed file matches `on:` | `on:` (file path glob) | Claude `SessionEnd`; Codex `Stop`; Gemini `AfterAgent` |
+
+### Reserved for future use
+
+Schema is documented so new declarations can be written forward-compatibly; runners will add dispatch support as the need arises.
+
+| `hook:` value | When it will fire | Matcher |
+|---|---|---|
+| `agent-before-file-edit` | Before agent writes/edits a file (can block or modify content) | `on:` (glob) |
+| `agent-after-command` | After agent executes a shell command | `binary:` (structured) |
+| `agent-after-tool-call` | After agent invokes any named tool | `tool:` (name) |
+| `agent-before-prompt` | Before agent processes a user prompt | — |
+
+### Runner implementation notes (Claude Code)
+
+- **`agent-session-start`** maps to Claude's `SessionStart` event with `matcher: "startup|resume"` so the hook fires on fresh sessions AND on resumed sessions (`claude --resume`). This is what we want for orientation-style hooks — the agent gets the content whether the session is new or continuing. Stdout from the hook must be a JSON object of shape `{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: "..."}}`. The runner aggregates every matching entry's output.
+- **`agent-session-end`** maps to `SessionEnd`, **not** `Stop`. `Stop` is a per-turn interactive-mode event (fires when the user hits esc or the agent naturally ends a turn awaiting input) and does NOT fire in `claude -p` headless/batch mode. `SessionEnd` fires in both modes. This tripped us up on PR #141 — the lint check was silently not running for months.
+
+### Portability note
+
+The hook *mechanism* is designed to travel across agent frameworks (Claude Code, Codex, Gemini CLI all use JSON-over-stdin + exit-2-blocks). The hook *type names* and *matcher shapes* also travel: Claude Code's `PreToolUse` and Gemini's `BeforeTool` both fire at the same semantic point.
+
+What does NOT travel cleanly is **framework-specific tool names**:
+- `agent-before-command` / `agent-after-command` are portable — runners translate to whichever tool name the current framework uses for shell execution (`Bash` on Claude/Codex, `run_shell_command` on Gemini).
+- `agent-after-file-edit` is portable — runners translate to `Edit|Write` on Claude, `write_file|replace` on Gemini.
+- `agent-before-tool-call` uses literal framework tool names in the `tool:` matcher. Hooks written against a Claude-specific tool (e.g. `ScheduleWakeup`) simply won't match on other frameworks — they're silently skipped rather than erroring. To support multiple frameworks, write separate entries per framework.
+
+## Matcher shapes
+
+### `on:` (file path glob)
+
+For hooks that fire on file edits or on session end. Standard glob syntax, matched against the edited file's path (relative to repo root). Session-end hooks use `on:` as "any changed file in this session matches this glob" — a single match triggers the check once.
+
+```yaml
+on: "collectors/*/lunar-collector.yml"    # exact subtree
+on: "policies/**/*.py"                    # recursive descent
+on: "**/*.yml"                            # anything ending in .yml
+```
+
+### `when:` (nudge gate)
+
+Only valid on `agent-after-file-edit-nudge` entries. Optional bash test expression that decides whether the nudge fires. If present, the runner executes `when:` with `{file}` substituted; the nudge surfaces only when the expression exits 0. If absent, the nudge always fires on matched files.
+
+```yaml
+# Always fires when an SVG under assets/ is edited:
+- name: svg-logo-sourcing
+  hook: agent-after-file-edit-nudge
+  on: "**/assets/*.svg"
+  message: "Reminder: check simple-icons for an official logo before creating one."
+
+# Fires only when the edited manifest declares a CI-type hook:
+- name: ci-collector-testing-reminder
+  hook: agent-after-file-edit-nudge
+  on: "collectors/*/lunar-collector.yml"
+  when: "grep -q 'type: ci-' {file}"
+  message: "Reminder: test CI collectors on cronos with a real CI run."
+```
+
+### `binary:` (structured command matcher)
+
+For hooks that fire on shell commands. Mirrors the `ci-before-command` collector hook matcher so declarations are portable between CI and agent environments.
+
+Today the MVP implements just `binary.name` (exact binary name match); the rest is documented for forward compatibility:
+
+```yaml
+binary:
+  name: <name>              # Exact binary name match, OR
+  name_pattern: <regex>     # Regex on binary name (mutually exclusive with name)
+args:                       # (future) positional/flag matchers
+  - value: <arg>
+  - flag: <flag>
+    value_pattern: <regex>
+args_pattern: <regex>       # (future) regex on full args string
+envs:                       # (future) env-var matchers
+  - name: <var>
+    value: <value>
+```
+
+The runner extracts the primary binary from the command about to execute, stripping:
+- A leading `cd <path> && ...` prefix (supports unquoted, `"double"`, `'single'` quoted paths, and `~/` expansion).
+- Env-var assignments (`FOO=bar CMD arg` → `CMD` is the primary binary).
+
+## `run:` field
+
+- A path ending in `.sh` (relative to repo root) → executed with the PreToolUse JSON on stdin.
+- Anything else → executed as an inline shell expression. For file hooks, `{file}` is substituted with the edited file path before execution.
+
+## Exit codes
+
+- `0` → allow / check passes.
+- Non-zero → block (for before-command) OR surface as a nudge/finding (for after-file-edit, session-end). See the specific runner for how non-zero is interpreted in its context.
+
+For `agent-before-command`, non-zero stderr is propagated to the agent as the blocking message. Write them to be actionable.
+
+## Installed hooks
+
+### `phase-guidance.sh` — `agent-session-start`
+
+Fires once at the start of every agent session (fresh or resumed). Emits a markdown table that routes the agent to the right section of `.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md` based on where the current PR/ticket sits in the spec → impl → merge lifecycle.
+
+Keeps the playbook as the single source of truth — the hook's job is just to prompt the agent to identify the phase and read the right section. Prevents the "spent hours in spec phase, blew right past the implementation checklist" failure mode observed on ENG-494.
+
+### `lunar-cli-guard.sh` — `agent-before-command`
+
+Blocks `lunar` CLI commands when context is wrong. Declared in `checks.yml` as `agent-before-command` matching `binary.name: lunar`. The script:
+
+- Skips `lunar --help` / `--version` / `-h` / `-v` (they don't need hub access or a config file).
+- Requires `LUNAR_HUB_TOKEN` to be set.
+- For subcommands that talk to the hub or read plugin manifests (`collector`, `policy`, `component`, `catalog`, `sql`, `secret`, `hub`), requires `lunar-config.yml` or `lunar-config.yaml` in the effective working directory.
+- Parses a leading `cd <path> && ...` prefix to compute the effective working directory — supports unquoted, `"double"`, and `'single'` quoted paths, plus `~/` expansion.
+
+### `block-schedule-wakeup` (inline) — `agent-before-tool-call`
+
+Inline `run: "exit 2"` entry that blocks Claude Code's `ScheduleWakeup` tool. No script file — the whole hook is declared in `checks.yml`.
+
+Rationale: `ScheduleWakeup` emits a "wake me up in N seconds" event and exits, but this execution environment has no handler for those events. A scheduled wakeup turns into a silent park until the next human nudge. The hook forces agents back to `Monitor` (same-invocation polling) or exit-and-event flow.
+
+This hook is Claude-specific (the tool name is a Claude Code built-in). Other frameworks with similar scheduling primitives would need their own entry — the matcher uses the framework's literal tool name.
+
+## Validations vs nudges (file-edit hooks)
+
+Use the right hook type for what you actually want:
+
+| I want to... | Use | `run:` behavior |
+|---|---|---|
+| Block or flag a file that's objectively wrong | `agent-after-file-edit` | Runs a real test command; non-zero exit surfaces `message:` |
+| Remind the agent about something relevant to this file | `agent-after-file-edit-nudge` | No `run:` — the `message:` is always surfaced (optionally gated by `when:`) |
+
+Before this split, every reminder had to be written as `run: "exit 1"` with the message in `message:`, which conflated "reminder" with "validation failure" and made the intent unclear. Nudges now skip the shell dance entirely.
+
+## Adding a new hook
+
+1. Decide whether the logic is inline-friendly. If so, add an entry to `checks.yml` with `run: <shell>` and stop here.
+2. Otherwise, drop a `*.sh` file in this directory with `#!/bin/bash` and a descriptive header comment. `chmod +x` it.
+3. Add an entry in `checks.yml`:
+   ```yaml
+   - name: <name>
+     hook: <one of the implemented types above>
+     # matcher fields for the chosen type...
+     run: .lunar/hooks/<script>.sh
+     message: <human-readable rationale>
+   ```
+4. Test locally with a synthetic payload. Example shapes:
+   - `agent-after-file-edit`: `{"tool_input": {"file_path": "/abs/path"}, "cwd": "/abs/cwd"}` (file path)
+   - `agent-before-command`: `{"tool_input": {"command": "...", "description": "..."}, "cwd": "/abs/cwd"}` (shell command)
+   - `agent-session-end`: `{"cwd": "/abs/cwd"}` (no tool-level input; runner gathers the list of changed files itself)
+5. Hooks should fail fast. Agent-side runners typically cap PreToolUse execution at a few seconds across all hooks; `agent-after-file-edit` allows ~60s per check; `agent-session-end` allows ~120s.

--- a/.lunar/hooks/lunar-cli-guard.sh
+++ b/.lunar/hooks/lunar-cli-guard.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# lunar-cli-guard.sh — PreToolUse hook for Bash.
+# Validates execution context before lunar CLI commands run.
+# Exit 0 = allow, Exit 2 = block (stderr shown to Claude)
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r ".tool_input.command // empty")
+CWD=$(echo "$INPUT" | jq -r ".cwd // empty")
+
+# Extract actual lunar CLI invocations (not "lunar" appearing in paths,
+# filenames, string literals, etc). Match `lunar` only at the start of a
+# command word: beginning of line, after `&&`, `||`, `|`, `;`, or newline.
+# Then capture the rest of that command segment (up to the next separator).
+LUNAR_INVOCATIONS=$(echo "$COMMAND" | grep -oE '(^|[\&\|\;[:space:]])lunar([[:space:]][^|&;]*)?' | sed -E 's/^[[:space:]&|;]*//')
+[ -z "$LUNAR_INVOCATIONS" ] && exit 0
+
+# If every lunar invocation is --help / --version / `lunar` alone, skip checks.
+NON_HELP=$(echo "$LUNAR_INVOCATIONS" | grep -vE '^lunar([[:space:]]|$).*(--help|--version|-h\b|-v\b)' | grep -vE '^lunar[[:space:]]*$')
+[ -z "$NON_HELP" ] && exit 0
+
+if [ -z "$LUNAR_HUB_TOKEN" ]; then
+  echo "LUNAR_HUB_TOKEN is not set. Export it before running lunar commands:" >&2
+  echo "  export LUNAR_HUB_TOKEN=<token>" >&2
+  echo "Token comes from the hub deployment (see your agent environment secrets)." >&2
+  exit 2
+fi
+
+# Determine the effective working directory for the lunar command.
+# If the command starts with `cd <path> && ...`, honour that cd target.
+# Otherwise fall back to Claude's reported CWD.
+# Supports: `cd /abs/path`, `cd ~/rel`, `cd "path with spaces"`, `cd 'path'`.
+EFFECTIVE_CWD="$CWD"
+TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
+if [[ "$TRIMMED" =~ ^cd[[:space:]]+ ]]; then
+  REST="${TRIMMED#cd}"
+  REST="${REST#"${REST%%[![:space:]]*}"}"
+  if [[ "$REST" =~ ^\"([^\"]+)\"[[:space:]]*\&\&(.*)$ ]]; then
+    CD_PATH="${BASH_REMATCH[1]}"
+  elif [[ "$REST" =~ ^\'([^\']+)\'[[:space:]]*\&\&(.*)$ ]]; then
+    CD_PATH="${BASH_REMATCH[1]}"
+  elif [[ "$REST" =~ ^([^[:space:]\&\|\;]+)[[:space:]]*\&\&(.*)$ ]]; then
+    CD_PATH="${BASH_REMATCH[1]}"
+  else
+    CD_PATH=""
+  fi
+  if [ -n "$CD_PATH" ]; then
+    CD_PATH="${CD_PATH/#\~/$HOME}"
+    EFFECTIVE_CWD="$CD_PATH"
+  fi
+fi
+
+# For lunar commands that talk to the hub / read plugin manifests
+# (collector, policy, component, catalog, sql, secret, hub), require a
+# lunar-config.yml in the effective working directory.
+if echo "$NON_HELP" | grep -qE '^lunar (collector|policy|component|catalog|sql|secret|hub)\b'; then
+  if [ ! -f "$EFFECTIVE_CWD/lunar-config.yml" ] && [ ! -f "$EFFECTIVE_CWD/lunar-config.yaml" ]; then
+    echo "No lunar-config.yml in effective directory ($EFFECTIVE_CWD)." >&2
+    echo "Run lunar commands from a directory with lunar-config.yml, e.g.:" >&2
+    echo "  cd ~/repos/pantalasa-cronos-lunar && lunar collector dev ..." >&2
+    echo "  cd ~/repos/pantalasa-cronos/lunar && lunar collector dev ..." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.lunar/hooks/lunar-cli-guard.sh
+++ b/.lunar/hooks/lunar-cli-guard.sh
@@ -9,9 +9,13 @@ CWD=$(echo "$INPUT" | jq -r ".cwd // empty")
 
 # Extract actual lunar CLI invocations (not "lunar" appearing in paths,
 # filenames, string literals, etc). Match `lunar` only at the start of a
-# command word: beginning of line, after `&&`, `||`, `|`, `;`, or newline.
-# Then capture the rest of that command segment (up to the next separator).
-LUNAR_INVOCATIONS=$(echo "$COMMAND" | grep -oE '(^|[\&\|\;[:space:]])lunar([[:space:]][^|&;]*)?' | sed -E 's/^[[:space:]&|;]*//')
+# command word, which at the byte level means: beginning of line, or
+# immediately after a shell separator (`&`, `|`, `;`). We deliberately
+# DO NOT treat plain whitespace as a command-word boundary, because that
+# would also match "lunar" inside quoted strings (commit messages,
+# `echo`/`printf` arguments, `gh pr create --body ...`, etc.) — see
+# Claude-review feedback on PR #140.
+LUNAR_INVOCATIONS=$(echo "$COMMAND" | grep -oE '(^|[\&\|\;])[[:space:]]*lunar([[:space:]][^|&;]*)?' | sed -E 's/^[[:space:]&|;]*//')
 [ -z "$LUNAR_INVOCATIONS" ] && exit 0
 
 # If every lunar invocation is --help / --version / `lunar` alone, skip checks.
@@ -45,7 +49,14 @@ if [[ "$TRIMMED" =~ ^cd[[:space:]]+ ]]; then
   fi
   if [ -n "$CD_PATH" ]; then
     CD_PATH="${CD_PATH/#\~/$HOME}"
-    EFFECTIVE_CWD="$CD_PATH"
+    # Resolve relative paths against the payload-reported $CWD, not against
+    # the hook process's CWD (which depends on whatever shell Claude's
+    # hook runner inherited). Absolute paths and ~-expanded paths pass
+    # through unchanged. Fixes Claude-review comment 3 on PR #140.
+    case "$CD_PATH" in
+      /*) EFFECTIVE_CWD="$CD_PATH" ;;
+      *)  EFFECTIVE_CWD="$CWD/$CD_PATH" ;;
+    esac
   fi
 fi
 

--- a/.lunar/hooks/phase-guidance.sh
+++ b/.lunar/hooks/phase-guidance.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# phase-guidance.sh — agent-session-start hook.
+# Stdin: SessionStart JSON ({ source, cwd }). Ignored — content is static.
+# Stdout: markdown additionalContext routing the agent to the right
+# playbook section for whatever phase their current PR / ticket sits in.
+#
+# Keeps the playbook as single source of truth (deep content lives in
+# .ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md); this script just tells
+# the agent how to figure out the phase and which section to read.
+
+cat <<'EOF'
+## Where are you in the PR lifecycle?
+
+Before doing any substantive work on a PR-related session, identify which
+phase the work is in and read the matching playbook section. Each phase
+has a different checklist, and finishing one phase is usually NOT the
+same as finishing the work.
+
+| Signal | Phase | Read in `.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md` |
+|---|---|---|
+| PR title contains `[Spec Only]` / `[Spec]`; no scripts (`*.sh`) in `collectors/<name>/`, no `*.py` in `policies/<name>/` | **Spec review** | `## Spec PR` + `### Then wait for go-ahead` |
+| Spec approved by secondary reviewer (e.g. Vlad); implementation not yet written | **Transitioning to implementation** | `## Implementation (same PR)` + entirety of `## Testing` |
+| PR title no longer has `[Spec Only]`; implementation scripts/policies present; CI running or green | **Implementation review** | `## Testing` (14 steps) + `## Integration Test Evidence` |
+| All required reviewers approved; CI green | **Ready to merge** | `### Merge` (end of playbook) |
+
+**Critical**: "CI green" is not the finish line for implementation PRs.
+The playbook's `## Testing` section requires a full cronos round-trip
+(deploy branch ref to cronos, trigger collection, gather JSON evidence,
+post screenshots) before the PR is ready for final review. Running
+`lunar collector dev` locally is not sufficient for CI-hook collectors
+— those only fire during actual CI on cronos.
+
+**How to check your phase right now:**
+1. `gh pr view <PR> --json title,reviews,mergeable` to see PR title, approvals, CI status.
+2. `ls collectors/<name>/ policies/<name>/` on the branch to see what's implemented.
+3. If the PR transitioned (title changed, new approval came in), the
+   previous phase's checklist no longer applies.
+EOF


### PR DESCRIPTION
## Summary

Adopts a consistent `<env>-<before|after>-<noun>` convention for every hook declaration in `.lunar/checks.yml`, mirroring the existing `ci-before-command` / `ci-after-command` vocabulary on Lunar collector CI hooks. Introduces three `agent-*` hooks in this PR.

Hard cutover on existing entries — this repo is the only consumer.

## The vocabulary

### Implemented in runners

| `hook:` | When it fires | Matcher | Framework event |
|---|---|---|---|
| `agent-after-file-edit` | Hard validation after a file edit | `on:` (glob) | Claude `PostToolUse` `Edit\|Write`; Gemini `AfterTool` `write_file\|replace` |
| `agent-after-file-edit-nudge` | Advisory reminder after a file edit (optionally gated by `when:`) | `on:` (glob), optional `when:` (bash test) | same as above |
| `agent-before-command` | Before agent runs a shell command | `binary:` (structured) | Claude/Codex `PreToolUse` `Bash`; Gemini `BeforeTool` `run_shell_command` |
| `agent-before-tool-call` | Before agent invokes any named tool | `tool:` (framework tool name) | Claude/Codex `PreToolUse`; Gemini `BeforeTool` |
| `agent-session-end` | When agent session ends, if any changed file matches `on:` | `on:` (glob) | Claude/Codex `Stop`; Gemini `AfterAgent` |

### Reserved for future use

`agent-before-file-edit`, `agent-after-command`, `agent-after-tool-call`, `agent-session-start`, `agent-before-prompt`.

## Validations vs nudges

The file-edit family splits into two types to make intent explicit:

| Type | `run:` | Semantics |
|---|---|---|
| `agent-after-file-edit` | Required — a real test | Non-zero exit → surface `message:` as a finding |
| `agent-after-file-edit-nudge` | Not used | `message:` always surfaces when the file matches `on:` (and optional `when:` passes) |

Before this PR, every reminder was written as `run: "exit 1"` with the message in `message:`, which conflated "reminder" with "validation failure" and made the intent hard to read at a glance. The new type drops the `exit 1` boilerplate entirely.

Conditional nudges can use `when:` instead of inline shell. Example:

```yaml
- name: ci-collector-testing-reminder
  hook: agent-after-file-edit-nudge
  on: "collectors/*/lunar-collector.yml"
  when: "grep -q 'type: ci-' {file}"   # fires only when matcher passes
  message: "Reminder: test CI collectors on cronos ..."
```

Five of the ten existing entries migrate to the new nudge type; two of those use `when:`.

## New agent hooks in this PR

- **`lunar-cli-guard`** (`agent-before-command`) — blocks `lunar` CLI commands when context is wrong (missing `LUNAR_HUB_TOKEN`, missing `lunar-config.yml` in effective cwd). Honours `cd <path> && lunar ...` prefix parsing. Imperative script at `.lunar/hooks/lunar-cli-guard.sh`.

- **`block-schedule-wakeup`** (`agent-before-tool-call`) — blocks Claude Code's `ScheduleWakeup` tool, which emits a "wake me up in N seconds" event and exits. The execution environment has no handler for those events, so scheduled wakeups silently park workers mid-task. Inline `run: "exit 2"` with actionable `message:` surfaced by the runner.

## Glob fix

`lunar-verify.sh`'s internal glob-to-regex converter didn't handle leading `**/` correctly (required a leading slash in the path, so `**/foo.txt` matched `a/b/foo.txt` but not `foo.txt`). Fixed to treat leading `**/` as an optional directory prefix. Pre-existing bug, not introduced by this PR, but tripped during new tests.

## Files

- `.lunar/checks.yml` — every entry carries an explicit `hook:` field. Header comment documents the full family.
- `.lunar/hooks/lunar-cli-guard.sh` — imperative script for `lunar-cli-guard`.
- `.lunar/hooks/README.md` — full schema reference including validations-vs-nudges guidance, `when:` field, matcher shapes, `run:` semantics, reserved hook types, and portability tiers.

## Portability

The hook mechanism (JSON-over-stdin, exit-2 blocks) is shared across Claude Code, Codex, and Gemini CLI — all three have converged on the same wire protocol. Hook type names and matcher shapes are portable: runners translate `agent-before-command` to whichever shell-execution tool the current framework uses (`Bash` on Claude/Codex, `run_shell_command` on Gemini).

`agent-before-tool-call` is portable in shape but not in values — the `tool.name` matcher uses the framework's literal tool name. Hooks targeting a Claude-specific tool like `ScheduleWakeup` simply won't match on other frameworks; they're silently skipped rather than erroring.

## Testing

- 12-case `agent-before-*` runner test suite
- 8-case `agent-after-file-edit*` runner test suite
- VM smoke tests end-to-end against deployed runners + deployed `checks.yml`
- `block-schedule-wakeup` confirmed blocking on the Bender VM with full actionable message reaching Claude
- Glob fix: `**/*screenshot*` now correctly matches `my-screenshot.png` (previously missed top-level files)

## Agent-side runner contract

The runners that dispatch these hooks live outside this repo (on Bender's agent VM at `~/.claude/hooks/`):

- One PreToolUse runner (`lunar-pre-tool.sh`) handles both `agent-before-command` and `agent-before-tool-call`. Settings.json registers a single `matcher: "*"` hook that sees every tool call; the runner reads `.lunar/checks.yml` and dispatches based on `hook:` + matcher shape.
- PostToolUse runner (`lunar-verify.sh`) handles both `agent-after-file-edit` and `agent-after-file-edit-nudge`.
- When a hook exits non-zero without writing to stderr, the runner falls back to emitting `[<name>] <message>` from the declaration. Simple `run: "exit 2"` inline entries don't need to echo their own messages.

## Test plan

- [ ] Primary reviewer approves naming + schema
- [ ] CI green (lint, test, all)
- [ ] Agent-side runners rolled out to any other agent VMs