### PR TITLE
secrets: default max_issues_threshold to 10

### DIFF
--- a/policies/secrets/README.md
+++ b/policies/secrets/README.md
@@ -36,8 +36,10 @@ policies:
     enforcement: report-pr
     # include: [executed, no-hardcoded-secrets]  # Only run specific checks
     with:
-      max_issues_threshold: "5"   # Fail if more than 5 issues
+      max_issues_threshold: "10"  # Default — fails only when issue count exceeds this
 ```
+
+**Threshold semantics.** `max_issues_threshold` is a remediation lever: `max-issues` fails only when the number of findings *exceeds* the threshold. It must be a positive integer — for zero-tolerance enforcement, enable the `no-hardcoded-secrets` check instead (it's unconditional and has no threshold to misconfigure). The default of `"10"` is a safe starting point for most teams; pair it with `no-hardcoded-secrets` to keep zero-tolerance pressure on new commits while `max-issues` acts as a ceiling for gradual remediation of existing findings.
 
 ## Examples
 

--- a/policies/secrets/lunar-policy.yml
+++ b/policies/secrets/lunar-policy.yml
@@ -45,4 +45,5 @@ policies:
 
 inputs:
   max_issues_threshold:
-    description: "Maximum number of secret issues allowed (must be configured)"
+    description: "Maximum number of secret issues allowed before max-issues fails. Must be a positive integer. Use no-hardcoded-secrets for zero-tolerance enforcement."
+    default: "10"

--- a/policies/secrets/max_issues.py
+++ b/policies/secrets/max_issues.py
@@ -6,7 +6,7 @@ from lunar_policy import Check, variable_or_default
 def main(node=None):
     c = Check("max-issues", "Secret findings within threshold", node=node)
     with c:
-        threshold_str = variable_or_default("max_issues_threshold", "0")
+        threshold_str = variable_or_default("max_issues_threshold", "10")
         try:
             threshold = int(threshold_str)
         except ValueError:


### PR DESCRIPTION
## Why

The `secrets.max-issues` policy shipped with contradictory configuration: the YAML declared `max_issues_threshold` as *"must be configured"*, but the Python used a default of `"0"` — which the existing `<= 0` guard then (correctly) rejected as `"must be a positive integer"`. Net effect: the policy always errored on any component where the operator hadn't set `with: { max_issues_threshold: "<something>" }`.

Reported by Brandon while standing up the `pantalasa/lunar` release-ledger demo on `lunar.demo.earthly.dev` — every backend commit was failing with:

```
ValueError: Policy misconfiguration: 'max_issues_threshold' must be a positive integer, got '0'
```

## What

Narrow fix: set a non-zero default in both places (`"10"`, a realistic remediation ceiling) and reword the YAML description so it no longer says "must be configured." The `<= 0` guard stays as-is — a zero threshold would make `max-issues` redundant with the unconditional `no-hardcoded-secrets` check.

- `policies/secrets/lunar-policy.yml` — declare `default: "10"` on the input and reword the description.
- `policies/secrets/max_issues.py` — default `"0"` → `"10"`. Guard and error message unchanged.
- `policies/secrets/README.md` — update the install example to the new default; add a short "Threshold semantics" paragraph pointing users at `no-hardcoded-secrets` when they want zero-tolerance enforcement.

## Test plan

Ran the policy locally via `lunar policy dev` against `/tmp/secrets-{clean,dirty}.json` stubs from `pantalasa/lunar`:

| Threshold | Issues | Expected | Actual |
|---|---|---|---|
| default (`10`) | 0 | pass | ✅ pass (`less_or_equal (0)`) |
| default (`10`) | 3 | pass | ✅ pass (`less_or_equal (3)`) |
| `"5"` | 3 | pass | ✅ pass (`less_or_equal (3)`) |
| `"2"` | 3 | fail | ❌ "Secret findings (3) exceeds threshold (2)" |
| `"0"` | — | error | `ValueError: ... must be a positive integer, got '0'` (guard preserved) |

## Notes

- Not folding in the sibling `sast.max-total` / `sca.max-total` policies (which have the same self-inconsistent `default "0"` + `<= 0` guard) because `max_total_threshold` is less obviously misconfigured there (SAST/SCA on a clean repo naturally have 0 findings). Happy to open a follow-up PR if the pattern should be applied there too.

*This fix was generated by AI.*