### PR TITLE
Drop CodeRabbit summon from PR workflow docs

### DIFF
--- a/.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md
+++ b/.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md
@@ -168,9 +168,7 @@ revisit it if a reviewer flags something you don't recognize.
 | Using `git add .` or `git add -A` | Stages unintended files (test configs, temp files, etc.). | Always `git add` specific directories: `git add collectors/<name>/` or `git add policies/<name>/`. |
 | Merging with only one approval | Both reviewers need to approve unless one explicitly waives. | Wait for both. |
 | Not posting test results on the PR | Reviewers need evidence, not trust. | Always post test results with JSON output, screenshots, and the test matrix template. See [`phases/implementation.md`](phases/implementation.md) Step 8. |
-| Posting `@coderabbitai review` manually | The Bender server posts the summon automatically on the draft→ready webhook. Doing it yourself in draft state is the failure mode that prompted this automation (PR #162) — CodeRabbit ignored the in-draft summon and never reviewed. | Don't post it. Leave the PR in draft until a human marks it ready; the server handles the summon. See [`phases/implementation.md`](phases/implementation.md) Step 0. |
-| Running `gh pr ready` from the worker | The summon trigger is human-driven specifically so bot-marked-ready events don't fire it. A worker flipping the PR ready means the summon won't fire. | Leave the draft→ready flip to a human (the requester). |
-| Ignoring CodeRabbit review feedback | Once CodeRabbit reviews (on ready or on subsequent pushes), unresolved comments slow down human review. | Address or reply to every CodeRabbit review comment before requesting human review. Use judgment — CodeRabbit sometimes flags non-issues; reply explaining why and resolve the thread. |
+| Running `gh pr ready` from the worker | The draft→ready flip is a human-driven signal that implementation is ready for review. A worker flipping it short-circuits that handoff. | Leave the draft→ready flip to a human (the requester). |
 | Leaving branch refs in cronos config | The branch gets deleted on merge, breaking all manifest syncs. | Undeploy from cronos before merge (see [`phases/merge.md`](phases/merge.md) pre-merge checklist). |
 
 ### Docker images

--- a/.ai-implementation/phases/impl-review.md
+++ b/.ai-implementation/phases/impl-review.md
@@ -29,10 +29,6 @@ see [`LUNAR-PLUGIN-PLAYBOOK-AI.md`](../LUNAR-PLUGIN-PLAYBOOK-AI.md).
 
 ## What to do here
 
-CodeRabbit reviews the PR once the Bender server posts `@coderabbitai review` on your behalf — that's triggered automatically when a human flips the PR out of draft (see [`phases/implementation.md`](implementation.md) Step 0). If CodeRabbit hasn't reviewed by the time you're seeing this phase, it most likely means the PR is still in draft or the ready-for-review event came from a bot rather than a human; ask the requester to retoggle ready or check the server logs for `[coderabbit-summon]`. Once summoned, CodeRabbit re-reviews on subsequent pushes automatically.
-
-Address its feedback, but **use judgment** — CodeRabbit sometimes flags things that aren't real issues. If a comment is wrong or irrelevant, reply explaining why and resolve the thread. When you've addressed a valid comment (pushed a fix), resolve that thread too. Don't leave conversations hanging.
-
 **Implementation review may trigger spec changes.** Reviewers may ask you to adjust the YAML manifest, README, or Component JSON paths even after implementation is added. This is normal — make the changes. **Re-test after significant changes** (logic changes, new assertions, changed Component JSON paths). A quick `lunar collector dev` or `lunar policy dev` run is enough — post updated results on the PR if the previous results are now stale. See the testing steps in [`phases/implementation.md`](implementation.md) if you need a refresher.
 
 Wait for **both reviewers** to approve the PR via GitHub review.

--- a/.ai-implementation/phases/implementation.md
+++ b/.ai-implementation/phases/implementation.md
@@ -65,20 +65,6 @@ Follow this checklist **in order**. Every step must be completed before moving t
 
 Reviewers expect to see your test evidence on the PR before their review is meaningful. A PR comment with Grafana screenshots + Component JSON output (Step 8) is what unblocks implementation review — not vice versa.
 
-### Step 0: CodeRabbit summon is automatic — leave the PR in draft until ready
-
-You do **not** post `@coderabbitai review` yourself. The Bender server watches GitHub webhooks and posts the summon automatically the moment a human (reviewer or PR author) marks the PR ready for review. That's the only transition CodeRabbit reliably acts on — comments posted while the PR is still in draft get ignored (we burned PR #162 confirming this).
-
-What this means for you, the worker:
-
-- **Keep the PR in draft** while you're implementing, pushing, and posting test evidence. CodeRabbit will not review it yet, and that's intentional.
-- **Do not run `gh pr ready` yourself.** Leave the draft→ready flip to a human (the requester, typically). When they mark it ready, the server posts the summon.
-- **Do not paste `@coderabbitai review` manually.** The server is idempotent — even if you did, it would only post once per PR — but it's noise, and it's now somebody else's job.
-
-If for some reason CodeRabbit really did not review after a human marked it ready (the post landed but no review came back within a few minutes), check the server logs for `[coderabbit-summon]`. If the summon never fired, the human-vs-bot gate likely dropped it; ping the reviewer to retoggle ready or post the comment manually as a fallback.
-
-(Spec-only PRs are already covered by this: a spec PR stays in draft the whole time, so no summon fires. The summon only happens when you flip to ready, which by convention only happens at implementation time.)
-
 ### Step 1: Write implementation code
 
 Write the scripts referenced in the YAML manifest. Commit locally but do not push yet.

--- a/.ai-implementation/phases/spec.md
+++ b/.ai-implementation/phases/spec.md
@@ -129,7 +129,7 @@ The PR description must include:
 
 Create a draft PR with the spec files only. Title should contain `[Spec Only]` or `[Spec]` so the phase-guidance hook can recognize the phase. Assign the **primary reviewer** (the person who requested the work, or who will iterate on the design with you).
 
-**Do NOT post `@coderabbitai review` and do NOT flip the PR out of draft.** CodeRabbit is an implementation-level reviewer — there's no implementation code in a spec PR, so summoning is noise. You don't need to summon manually anyway: the Bender server auto-posts `@coderabbitai review` when a human marks the PR ready for review (see [`phases/implementation.md`](implementation.md) Step 0). Spec PRs stay in draft for the whole spec phase, so no summon fires — exactly the behavior we want.
+**Keep the PR in draft for the whole spec phase.** Don't flip it to ready until implementation is done — the draft→ready transition is the normal "implementation is ready for review" signal.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,7 @@ If someone asks you to do something code-related and you're not sure what they m
 - For lunar-lib: clone if not present, create feature branch, work, push, open draft PR
 - Commit messages should be descriptive (not "fix stuff")
 - **Always open PRs as draft:** `gh pr create --draft`
-- **CodeRabbit summon is automatic — do not post it yourself.** The Bender server watches GitHub webhooks and posts `@coderabbitai review` on its own when a human marks the PR ready for review (the `pull_request.ready_for_review` action with a human in PEOPLE.json as the sender). CodeRabbit ignores summons posted while a PR is still in draft (PR #162 was the canary), which is why we moved this to the draft→ready transition.
-  - **Keep PRs in draft** while you implement, push, and post test evidence. CodeRabbit will not review yet, and that's intentional.
-  - **Do not run `gh pr ready` yourself.** Leave the flip to ready for a human — that's what triggers the summon.
-  - Once summoned, CodeRabbit re-reviews on every push automatically. You only address its feedback; you never re-summon.
+- **Keep PRs in draft** while you implement, push, and post test evidence. Leave the draft→ready flip to a human (the requester, typically); a worker shouldn't run `gh pr ready` on its own.
 - **Reviewer assignment is a two-step process:**
   1. Add the person who requested the work as the default reviewer: `gh pr edit <PR> --add-reviewer <username>`
      - If triggered from Linear, add the ticket creator


### PR DESCRIPTION
## Summary

The draft→ready auto-summon (added in #162) didn't reliably trigger CodeRabbit reviews. We're replacing CodeRabbit with a companion review bot (Fry) for Bender's PRs — work-in-progress in `earthly/bender`. This PR strips the worker-facing docs that still point at the dead summon path.

## What's removed

- `CLAUDE.md` — the "CodeRabbit summon is automatic" bullet + its sub-bullets. Kept "open as draft + keep in draft" so the workflow guidance is intact.
- `.ai-implementation/phases/implementation.md` — Step 0 ("CodeRabbit summon is automatic — leave the PR in draft until ready"). The "keep in draft until evidence is posted" guidance is already covered by the testing-checklist intro just above it.
- `.ai-implementation/phases/impl-review.md` — the paragraph about CodeRabbit reviewing on the server's behalf and how to debug a missing summon.
- `.ai-implementation/phases/spec.md` — the "Do NOT post @coderabbitai review" reassurance; replaced with a one-liner that says to keep the PR in draft for the whole spec phase.
- `.ai-implementation/LUNAR-PLUGIN-PLAYBOOK-AI.md` — the three common-mistakes table rows about CodeRabbit (manual summon, gh pr ready, ignoring CodeRabbit feedback). Kept a slimmed-down `gh pr ready` row since the draft→ready discipline still applies.

## Not touched

- `collectors/coderabbit/` and `policies/ai/` — those are real Lunar plugins (CodeRabbit-as-a-collector for SDLC data) and unrelated to the bender review-summon flow.

## Companion PR

earthly/bender#35 — removes the server-side `summonCodeRabbitOnReady` function, the `coderabbitai[bot]` / `claude[bot]` actor-allowlist entries, and the equivalent bullet in bender's own `CLAUDE.md`.

## Test plan

- [x] `git grep` for `coderabbitai`, `@claude review`, `Step 0`, `coderabbit-summon` in `CLAUDE.md` + `.ai-implementation/` — zero hits remaining
- [ ] CI green

*This fix was generated by AI.*