### PR TITLE
docs: fix audit findings in ai-context references

### DIFF
--- a/ai-context/about-lunar.md
+++ b/ai-context/about-lunar.md
@@ -76,11 +76,11 @@ Guardrails are your engineering standards expressed as code. They verify that ap
 - CODEOWNERS files must be valid
 - SBOMs must be generated for compliance
 
-Lunar includes 100+ pre-built guardrails across categories like testing, security, compliance, operational readiness, and infrastructure. You can also create custom guardrails for your unique standards.
+Lunar includes 200+ pre-built guardrails across categories like testing, security, compliance, operational readiness, and infrastructure. You can also create custom guardrails for your unique standards.
 
 ### Gradual Enforcement
 
-Not every standard needs to block deployments immediately. Lunar supports five enforcement levels:
+Not every standard needs to block deployments immediately. Lunar supports six enforcement levels:
 
 1. `draft`: Visible only to the platform team for testing
 2. `score`: Affects application health scores in dashboards

--- a/ai-context/cataloger-patterns.md
+++ b/ai-context/cataloger-patterns.md
@@ -26,7 +26,7 @@ echo "$COMPONENTS" | jq '
       tags: .metadata.tags
     }
   }] | add
-' | lunar catalog --json '.components' -
+' | lunar catalog raw --json '.components' -
 ```
 
 ## Pattern 2: Database Sync (cron hook)
@@ -50,7 +50,7 @@ psql "$LUNAR_SECRET_DB_URL" -t -A -c "
   ))
   FROM services
   WHERE active = true
-" | lunar catalog --json '.components' -
+" | lunar catalog raw --json '.components' -
 ```
 
 ## Pattern 3: Central Repository Files (repo hook)
@@ -64,10 +64,10 @@ set -e
 # Hook: type: repo, repo: github.com/acme/software-catalog
 
 # Import domains from TOML file
-cat domains.toml | toml2json | jq '.domains' | lunar catalog --json '.domains' -
+cat domains.toml | toml2json | jq '.domains' | lunar catalog raw --json '.domains' -
 
 # Import components from YAML file
-cat services.yaml | yq -o=json '.components' | lunar catalog --json '.components' -
+cat services.yaml | yq -o=json '.components' | lunar catalog raw --json '.components' -
 ```
 
 ## Pattern 4: Component-Level Augmentation (component-repo hook)
@@ -80,18 +80,21 @@ set -e
 
 # Hook: type: component-repo
 
-# Add tag if repo has a specific CI workflow
+# Detect tags from repo signals
+TAGS='[]'
 if grep -q '^name: Production Deploy$' .github/workflows/*.yml 2>/dev/null; then
-  lunar catalog component --tag production
+  TAGS=$(echo "$TAGS" | jq '. + ["production"]')
+fi
+if [ -f go.mod ]; then
+  TAGS=$(echo "$TAGS" | jq '. + ["go"]')
+elif [ -f package.json ]; then
+  TAGS=$(echo "$TAGS" | jq '. + ["javascript"]')
+elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
+  TAGS=$(echo "$TAGS" | jq '. + ["python"]')
 fi
 
-# Add tag based on language detection
-if [ -f go.mod ]; then
-  lunar catalog component --tag go
-elif [ -f package.json ]; then
-  lunar catalog component --tag javascript
-elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
-  lunar catalog component --tag python
+if [ "$TAGS" != "[]" ]; then
+  lunar catalog raw --json ".components.\"$LUNAR_COMPONENT_ID\".tags" "$TAGS"
 fi
 ```
 
@@ -110,11 +113,10 @@ gh repo list my-org --json name,owner,description,url \
   --limit 1000 | jq '
   [.[] | {
     (.url | gsub("https://"; "")): {
-      owner: .owner.login,
-      meta: {description: .description}
+      owner: .owner.login
     }
   }] | add
-' | lunar catalog --json '.components' -
+' | lunar catalog raw --json '.components' -
 ```
 
 ## Pattern 6: Multi-Source Aggregation (cron hook)
@@ -129,15 +131,15 @@ set -e
 
 # Fetch from primary source (Backstage)
 curl -fsS "$BACKSTAGE_API/entities" | \
-  jq '...' | lunar catalog --json '.components' -
+  jq '...' | lunar catalog raw --json '.components' -
 
 # Augment with ownership data from a spreadsheet export
 curl -fsS "$OWNERSHIP_SHEET_CSV" | \
-  csvjson | jq '...' | lunar catalog --json '.components' -
+  csvjson | jq '...' | lunar catalog raw --json '.components' -
 
 # Add domain hierarchy from internal API
 curl -fsS "$INTERNAL_API/domains" | \
-  jq '...' | lunar catalog --json '.domains' -
+  jq '...' | lunar catalog raw --json '.domains' -
 ```
 
 ## Pattern 7: Component-JSON Heuristics (component-cron hook)
@@ -153,14 +155,17 @@ set -e
 
 COMPONENT_JSON="$(lunar component get-json "$LUNAR_COMPONENT_ID")"
 
-# Tag based on k8s deployment namespace
+# Detect tags from Component JSON signals
+TAGS='[]'
 if echo "$COMPONENT_JSON" | jq -e '.k8s.deployments[]? | select(.namespace == "prod")' >/dev/null; then
-  lunar catalog component --tag production
+  TAGS=$(echo "$TAGS" | jq '. + ["production"]')
+fi
+if echo "$COMPONENT_JSON" | jq -e '.sca.dependencies[]? | select(.license == "AGPL-3.0")' >/dev/null; then
+  TAGS=$(echo "$TAGS" | jq '. + ["compliance-review"]')
 fi
 
-# Tag based on dependency license
-if echo "$COMPONENT_JSON" | jq -e '.sca.dependencies[]? | select(.license == "AGPL-3.0")' >/dev/null; then
-  lunar catalog component --tag compliance-review
+if [ "$TAGS" != "[]" ]; then
+  lunar catalog raw --json ".components.\"$LUNAR_COMPONENT_ID\".tags" "$TAGS"
 fi
 ```
 

--- a/ai-context/cataloger-reference.md
+++ b/ai-context/cataloger-reference.md
@@ -196,8 +196,6 @@ Catalogers have access to these environment variables:
 
 | Variable | Description |
 |----------|-------------|
-| `LUNAR_CATALOGER_NAME` | Name of the current cataloger |
-| `LUNAR_CATALOGER_OWNER` | Owner of the cataloger |
 | `LUNAR_BIN_DIR` | Directory for installed binaries |
 | `LUNAR_PLUGIN_ROOT` | Root directory of the plugin (for plugins) |
 
@@ -236,84 +234,13 @@ lunar catalog raw [--json] <json-path> <value>
 
 ```bash
 # Write components to the catalog
-lunar catalog --json '.components' '{"github.com/acme/api": {"owner": "jane@acme.com"}}'
+lunar catalog raw --json '.components' '{"github.com/acme/api": {"owner": "jane@acme.com"}}'
 
 # Pipe JSON from command output
-gh repo list my-org --json name,owner | jq '...' | lunar catalog --json '.components' -
+gh repo list my-org --json name,owner | jq '...' | lunar catalog raw --json '.components' -
 
 # Write domains
-lunar catalog --json '.domains' '{"platform": {"owner": "platform-team@acme.com"}}'
-```
-
-#### Component Form
-
-Write or update a single component with structured flags.
-
-```bash
-lunar catalog component [options] [<json-value>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--name <n>` | Component name (required unless in component-repo hook) |
-| `--owner <owner>` | Component owner email |
-| `--branch <branch>` | Default branch name |
-| `--domain <domain>` | Domain path (e.g., `platform.api`) |
-| `--tag <tag>` | Add a tag (repeatable) |
-| `--ci-pipeline <name>` | Add a CI pipeline (repeatable) |
-| `--meta <key>=<value>` | Add metadata (string value, repeatable) |
-| `--meta-json <key>=<value>` | Add metadata (JSON value, repeatable) |
-
-**Examples:**
-
-```bash
-# Add component with flags
-lunar catalog component \
-  --name "github.com/acme/api" \
-  --owner "jane@acme.com" \
-  --domain "platform.backend" \
-  --tag "go" \
-  --tag "production"
-
-# Add tag to current component (in component-repo hook)
-lunar catalog component --tag production
-
-# Set metadata
-lunar catalog component \
-  --name "github.com/acme/api" \
-  --meta tier=1 \
-  --meta-json slos='{"latency_p99": 100}'
-```
-
-#### Domain Form
-
-Write or update a single domain.
-
-```bash
-lunar catalog domain [options] [<json-value>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--name <n>` | Domain name (required) |
-| `--description <desc>` | Domain description |
-| `--owner <owner>` | Domain owner email |
-| `--meta <key>=<value>` | Add metadata (string value, repeatable) |
-| `--meta-json <key>=<value>` | Add metadata (JSON value, repeatable) |
-
-**Examples:**
-
-```bash
-# Create a domain
-lunar catalog domain \
-  --name "platform" \
-  --description "Platform services" \
-  --owner "platform-team@acme.com"
-
-# Create nested domain
-lunar catalog domain \
-  --name "platform.backend" \
-  --description "Backend platform services"
+lunar catalog raw --json '.domains' '{"platform": {"owner": "platform-team@acme.com"}}'
 ```
 
 ### Path Syntax
@@ -346,10 +273,7 @@ The Catalog JSON has a predefined structure:
   "domains": {
     "<domain-name>": {
       "description": "<description>",
-      "owner": "<owner>",
-      "meta": {
-        "<key>": "<value>"
-      }
+      "owner": "<owner>"
     }
   },
   "components": {
@@ -358,10 +282,7 @@ The Catalog JSON has a predefined structure:
       "domain": "<domain>",
       "branch": "<branch>",
       "tags": ["<tag1>", "<tag2>"],
-      "ciPipelines": ["<pipeline1>", "<pipeline2>"],
-      "meta": {
-        "<key>": "<value>"
-      }
+      "ciPipelines": ["<pipeline1>", "<pipeline2>"]
     }
   }
 }
@@ -396,7 +317,7 @@ version: 0
 
 name: my-cataloger                    # Required: Must match directory name
 description: What this cataloger does # Required: Brief description
-author: team@example.com              # Required
+author: team@example.com              # Optional
 
 # Recommended: specify container image
 default_image: earthly/lunar-scripts:1.0.0
@@ -618,23 +539,6 @@ echo "Found $(echo "$COMPONENTS" | jq 'length') components"
 
 One cataloger should sync from one source. Create separate catalogers for different systems.
 
-### 6. Test Locally
-
-Use `lunar cataloger dev` to test catalogers locally:
-
-```bash
-# Run catalogers and output the resulting Catalog JSON
-lunar cataloger dev --output-json
-```
-
-### 7. Document Your Sources
+### 6. Document Your Sources
 
 Document what external systems your cataloger syncs from and any required secrets.
-
-### 8. View Current Catalog
-
-Inspect the current catalog state:
-
-```bash
-lunar cataloger get-json
-```

--- a/ai-context/collector-reference.md
+++ b/ai-context/collector-reference.md
@@ -178,7 +178,6 @@ hook:
   binary:
     name_pattern: python[0-9]*    # Regex on binary name
     dir: /usr/local/bin            # Exact dir match (or dir_pattern for regex)
-    use_path_dirs: true            # Restrict to PATH directories
   args:
     - value: build                 # Positional arg (order matters)
     - flag: --tag                  # Flag (order-independent)
@@ -187,8 +186,6 @@ hook:
   envs:
     - name: DEBUG
       value: "1"
-  max_process_depth: 1             # Only top-level processes
-  include_children_depth: 1        # Also trigger on direct children
 ```
 
 **Matching rules:**
@@ -300,14 +297,12 @@ Collectors have access to these environment variables:
 | `LUNAR_COMPONENT_BASE_BRANCH` | Base branch of PR (target branch) | `main` |
 | `LUNAR_COMPONENT_GIT_SHA` | Git SHA being evaluated | `abc123...` |
 | `LUNAR_COMPONENT_TAGS` | Component tags (JSON array) | `["go","backend"]` |
-| `LUNAR_COMPONENT_META` | Component metadata (JSON) | `{"tier":"1"}` |
 
 ### Collector Context
 
 | Variable | Description |
 |----------|-------------|
 | `LUNAR_COLLECTOR_NAME` | Name of the current collector |
-| `LUNAR_COLLECTOR_CI_PIPELINE` | CI pipeline name (for CI hooks) |
 | `LUNAR_PLUGIN_ROOT` | Root directory of the plugin (for plugins) |
 | `LUNAR_BIN_DIR` | Directory for installed binaries |
 
@@ -392,7 +387,8 @@ lunar collect [options] <json-path> <value> [<json-path> <value> ...]
 | Option | Description |
 |--------|-------------|
 | `-j`, `--json` | Interpret value as JSON (not raw string) |
-| `--component <id>` | Specify component (default: from environment) |
+| `--array-append` | Append to existing array instead of replacing |
+| `--pretty`, `-p` | Pretty-print the resulting JSON |
 
 ### Examples
 
@@ -659,7 +655,7 @@ version: 0
 
 name: my-collector                    # Required: Unique name (must match directory name)
 description: What this collector does # Required: Brief description
-author: team@example.com              # Required
+author: team@example.com              # Optional
 
 # Recommended: specify container image
 # Use default_image alone when plugin has no CI collectors

--- a/ai-context/core-concepts.md
+++ b/ai-context/core-concepts.md
@@ -255,8 +255,8 @@ version: 0
 
 hub:
   host: lunar-hub.internal.example.com
-  grpc_port: 9000
-  http_port: 8080
+  grpcPort: 9000
+  httpPort: 8080
 
 domains:
   payments:

--- a/ai-context/policy-reference.md
+++ b/ai-context/policy-reference.md
@@ -594,14 +594,8 @@ Policies have access to these environment variables:
 | Variable | Description |
 |----------|-------------|
 | `LUNAR_COMPONENT_ID` | Component identifier (e.g., `github.com/acme/api`) |
-| `LUNAR_COMPONENT_DOMAIN` | Component's domain |
-| `LUNAR_COMPONENT_OWNER` | Component owner email |
-| `LUNAR_COMPONENT_PR` | PR number (if applicable) |
 | `LUNAR_COMPONENT_GIT_SHA` | Git SHA being evaluated |
-| `LUNAR_COMPONENT_TAGS` | Component tags (JSON array) |
-| `LUNAR_COMPONENT_META` | Component metadata (JSON) |
-| `LUNAR_POLICY_NAME` | Name of the current policy |
-| `LUNAR_INITIATIVE_NAME` | Initiative the policy belongs to |
+| `LUNAR_COMPONENT_PR` | PR number (if applicable) |
 | `LUNAR_SECRET_<NAME>` | Secrets (avoid using in policies—prefer collectors) |
 
 ## Policy Inputs
@@ -1027,7 +1021,7 @@ version: 0
 
 name: my-policy                       # Required: Must match directory name
 description: What this policy checks  # Required: Brief description
-author: team@example.com              # Required
+author: team@example.com              # Optional
 
 default_image: earthly/lunar-scripts:1.0.0  # Recommended: specify base or custom image
 


### PR DESCRIPTION
## What
Fix doc audit findings in `ai-context/` references — wrong CLI examples, nonexistent env vars / hook fields, and config field-casing mistakes.

## Why
The doc audit (companion changes in earthly/lunar#1573, now merged) surfaced inaccuracies in the AI-context references vs. actual product behavior. These mistakes would mislead AI agents writing collectors, catalogers, and policies.

## How
- `cataloger-reference.md` / `cataloger-patterns.md`: replace removed `lunar catalog component` / `lunar catalog domain` subcommands with the current `lunar catalog raw` form; drop references to `lunar cataloger get-json` and `lunar cataloger dev --output-json`; remove nonexistent `meta` field on components and domains.
- `collector-reference.md`: drop nonexistent hook fields (`use_path_dirs`, `max_process_depth`, `include_children_depth`); drop nonexistent env vars (`LUNAR_COMPONENT_META`, `LUNAR_COLLECTOR_CI_PIPELINE`); fix `lunar collect` flag list (replace `--component` with real `--array-append` / `--pretty`).
- `policy-reference.md`: drop nonexistent env vars (`LUNAR_COMPONENT_DOMAIN`, `LUNAR_COMPONENT_OWNER`, `LUNAR_COMPONENT_TAGS`, `LUNAR_COMPONENT_META`, `LUNAR_POLICY_NAME`, `LUNAR_INITIATIVE_NAME`).
- `core-concepts.md`: fix hub config field casing (`grpc_port` → `grpcPort`, `http_port` → `httpPort`).
- Plugin manifests across docs: mark `author` as optional.

## Anything else
Companion to earthly/lunar#1573 (merged) and a parallel PR in earthly/skills.

🤖